### PR TITLE
Signup without code

### DIFF
--- a/api/controllers/CommunityController.js
+++ b/api/controllers/CommunityController.js
@@ -230,11 +230,6 @@ module.exports = {
       } else if (params.constraint === 'exists') {
         var exists = parseInt(rows[0].count) >= 1;
         data = {exists: exists};
-
-        // store the code for use later in signup
-        if (exists && params.column === 'beta_access_code' && req.param('store_value')) {
-          req.session.invitationCode = params.value;
-        }
       }
       res.ok(data);
     })

--- a/api/controllers/CommunityController.js
+++ b/api/controllers/CommunityController.js
@@ -180,6 +180,13 @@ module.exports = {
     });
   },
 
+  joinWithCode: function(req, res) {
+    Community.where('beta_access_code', req.param('code')).fetch()
+    .then(community => Membership.create(req.session.userId, community.id))
+    .then(() => res.ok({}))
+    .catch(res.serverError);
+  },
+
   leave: function(req, res) {
     res.locals.membership.destroyMe()
     .then(() => res.ok({}))

--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -17,14 +17,12 @@ var hasLinkedAccount = function(user, service) {
 };
 
 var findCommunity = function(req) {
-  if (req.session.invitationId) {
-    return Invitation.find(req.session.invitationId, {withRelated: ['community']})
-    .then(function(invitation) {
-      return [invitation.relations.community, invitation];
-    });
-  }
+  if (!req.session.invitationId) return;
 
-  return Promise.join(Community.where({beta_access_code: req.session.invitationCode}).fetch());
+  return Invitation.find(req.session.invitationId, {withRelated: ['community']})
+  .then(function(invitation) {
+    return [invitation.relations.community, invitation];
+  });
 };
 
 var finishOAuth = function(service, req, res, next) {
@@ -46,9 +44,6 @@ var finishOAuth = function(service, req, res, next) {
       } else {
         return findCommunity(req)
         .spread(function(community, invitation) {
-          if (!community && !invitation)
-            throw 'no community';
-
           var attrs = _.merge(_.pick(profile, 'email', 'name'), {
             community: (invitation ? null : community),
             account: {type: service, profile: profile}

--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -17,7 +17,7 @@ var hasLinkedAccount = function(user, service) {
 };
 
 var findCommunity = function(req) {
-  if (!req.session.invitationId) return;
+  if (!req.session.invitationId) return Promise.resolve([null, null]);
 
   return Invitation.find(req.session.invitationId, {withRelated: ['community']})
   .then(function(invitation) {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -36,9 +36,6 @@ module.exports = {
 
     return findContext(req)
     .then(ctx => {
-      if (!ctx.community && !ctx.invitation && !ctx.project)
-        throw 'bad code';
-
       var attrs = _.merge(_.pick(params, 'name', 'email'), {
         community: (ctx.invitation ? null : ctx.community),
         account: {type: 'password', password: params.password}

--- a/config/policies.js
+++ b/config/policies.js
@@ -76,7 +76,8 @@ module.exports.policies = {
     leave:           ['sessionAuth', 'checkAndSetMembership'],
     validate:        true,
     create:          ['sessionAuth'],
-    findForNetwork:  ['sessionAuth', 'inNetwork']
+    findForNetwork:  ['sessionAuth', 'inNetwork'],
+    joinWithCode:    ['sessionAuth']
   },
 
   PostController: {

--- a/config/routes.js
+++ b/config/routes.js
@@ -59,6 +59,7 @@ module.exports.routes = {
 
   'GET    /noo/community':                                'CommunityController.find',
   'POST   /noo/community':                                'CommunityController.create',
+  'POST   /noo/community/code':                           'CommunityController.joinWithCode',
   'POST   /noo/community/validate':                       'CommunityController.validate',
   'GET    /noo/community/:communityId':                   'CommunityController.findOne',
   'POST   /noo/community/:communityId':                   'CommunityController.update',


### PR DESCRIPTION
Not backwards-compatible; must be deployed with https://github.com/Hylozoic/hylo-frontend/pull/46 because it removes `req.session.invitationCode`