### PR TITLE
socket.io-redis 0.1.4 not up to date enough to work

### DIFF
--- a/api/services/Websockets.js
+++ b/api/services/Websockets.js
@@ -1,13 +1,6 @@
 export function pushToSockets (room, messageType, payload, socketToExclude) {
-  if (!sails.io) return
-  return Promise.map(Object.keys(sails.io.sockets.sockets), id => {
-    const socket = sails.io.sockets.sockets[id]
-    // for security reasons, only sockets that passed the checkAndSetPost policy
-    // get subscribed to the comment stream for that post
-    if (socket !== socketToExclude && socket.rooms[room]) {
-      console.log('emitting message: ', messageType, room)
-      socket.emit(messageType, payload)
-      return Promise.resolve()
-    }
-  })
+  // for security reasons, only sockets that passed the checkAndSetPost policy
+  // get subscribed to the comment stream for that post
+  sails.sockets.broadcast(room, messageType, payload, socketToExclude)
+  return Promise.resolve()
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "sendwithus": "^2.8.0",
     "slug": "^0.9.1",
     "socket.io-emitter": "^0.2.0",
-    "socket.io-redis": "^0.1.4",
+    "socket.io-redis": "1.1.1",
     "stream-buffers": "^3.0.1",
     "stripe": "^3.5.0",
     "striptags": "^2.0.2",


### PR DESCRIPTION
figured this out by switching `sails.config.sockets.adapter` to `memory` and it worked fine. then reading a bunch of the source code to do with socket.io-redis