### PR TITLE
don't treat empty string as an email list, fixes 'invite to tag' process

### DIFF
--- a/api/controllers/InvitationController.js
+++ b/api/controllers/InvitationController.js
@@ -89,12 +89,13 @@ module.exports = {
   create: function (req, res) {
     let tagName = req.param('tagName')
     const userIds = req.param('users')
+    const rawEmails = req.param('emails')
     return Promise.join(
       userIds && User.where('id', 'in', userIds).fetchAll(),
       Community.find(req.param('communityId')),
       tagName && Tag.find(tagName),
       (users, community, tag) => {
-        var emails = parseEmailList(req.param('emails'))
+        var emails = (rawEmails ? parseEmailList(rawEmails) : [])
         .concat(map(u => u.get('email'), get('models', users)))
 
         return Promise.map(emails, email => {


### PR DESCRIPTION
this trello card: https://trello.com/c/JOSC6Ivn/121-inviting-people-to-dev-topic-on-hylo-via-hylo-user-names-throws-both-success-and-error-state-at-same-time

![screen shot 2017-01-27 at 3 28 04 pm](https://cloud.githubusercontent.com/assets/1409121/22389981/85c83058-e4b6-11e6-8b78-749afe075a63.png)
