### PR TITLE
add total counts for pagination to our graphql api

### DIFF
--- a/api/graphql/fetcher.js
+++ b/api/graphql/fetcher.js
@@ -59,7 +59,6 @@ export default class Fetcher {
 
     const formatted = Object.assign(
       transform(attributes, (result, attr) => {
-        console.log(`${tableName} ${instance.id} ${attr} => ${camelCase(attr)} => ${instance.get(attr)}`)
         result[camelCase(attr)] = instance.get(attr)
       }, {}),
 

--- a/api/graphql/fetcher.js
+++ b/api/graphql/fetcher.js
@@ -1,7 +1,8 @@
 import { camelCase, toPairs, transform } from 'lodash'
 import { map } from 'lodash/fp'
-import applyPagination from './util/applyPagination'
+import applyPagination, { PAGINATION_TOTAL_COLUMN_NAME } from './util/applyPagination'
 import initDataLoaders from './util/initDataLoaders'
+import EventEmitter from 'events'
 
 export default class Fetcher {
   constructor (models) {
@@ -9,7 +10,7 @@ export default class Fetcher {
     this.loaders = initDataLoaders(models)
   }
 
-  fetchRelation (relation, paginationOpts) {
+  fetchRelation (relation, paginationOpts, tap) {
     const { targetTableName, type, parentFk } = relation.relatedData
     const loader = this.loaders[targetTableName]
 
@@ -17,12 +18,13 @@ export default class Fetcher {
       return loader.load(parentFk).then(x => this.format(targetTableName, x))
     }
 
-    const relationSpec = this.models[targetTableName]
+    const relationSpec = this._getModel(targetTableName)
     if (relationSpec.filter) relation = relationSpec.filter(relation)
 
     return this.loaders.queries.load(relation.query(q => {
-      applyPagination(q, paginationOpts)
+      applyPagination(q, targetTableName, paginationOpts)
     }))
+    .tap(tap)
     .then(instances => {
       // N.B. this caching doesn't take into account data added by withPivot
       instances.each(x => loader.prime(x.id, x))
@@ -32,8 +34,9 @@ export default class Fetcher {
   }
 
   fetchOne (tableName, id, idColumn = 'id') {
-    const { model, filter } = this.models[tableName]
-    const query = filter(model.where(idColumn, id))
+    const { model, filter } = this._getModel(tableName)
+    let query = model.where(idColumn, id)
+    if (filter) query = filter(query)
     return this.loaders.queries.load(query).then(instance => {
       if (!instance) return
       this.loaders[tableName].prime(instance.id, instance)
@@ -41,6 +44,12 @@ export default class Fetcher {
     })
   }
 
+  // once we have an instance, we format it; that means we look at the model
+  // definition and prepare a result object with attributes that match that
+  // definition. we set basic attributes directly, because they have already
+  // been retrieved at this point; but we set up relations as functions, so they
+  // will not run any additional database queries unless the current GraphQL
+  // query specifically asks for them.
   format (name, instance) {
     const { model, attributes, getters, relations } = this.models[name]
     const tableName = model.collection().tableName()
@@ -50,6 +59,7 @@ export default class Fetcher {
 
     const formatted = Object.assign(
       transform(attributes, (result, attr) => {
+        console.log(`${tableName} ${instance.id} ${attr} => ${camelCase(attr)} => ${instance.get(attr)}`)
         result[camelCase(attr)] = instance.get(attr)
       }, {}),
 
@@ -61,13 +71,33 @@ export default class Fetcher {
         const [ graphqlName, bookshelfName ] = typeof attr === 'string'
           ? [attr, attr] : toPairs(attr)[0]
 
+        const emitter = new EventEmitter()
+
         result[graphqlName] = ({ first, cursor, order }) => {
           const relation = instance[bookshelfName]()
-          return this.fetchRelation(relation, {first, cursor, order})
+          return this.fetchRelation(relation, {first, cursor, order}, instances => {
+            const total = instances.length > 0
+              ? instances.first().get(PAGINATION_TOTAL_COLUMN_NAME)
+              : null
+            emitter.emit('hasTotal', total)
+          })
         }
+
+        result[graphqlName + 'Total'] = () =>
+          new Promise((resolve, reject) => {
+            emitter.on('hasTotal', resolve)
+            setTimeout(() => reject(new Error('timeout')), 6000)
+          })
       }, {})
     )
 
     return formatted
+  }
+
+  _getModel (tableName) {
+    if (!this.models[tableName]) {
+      throw new Error(`missing model definition for ${tableName}`)
+    }
+    return this.models[tableName]
   }
 }

--- a/api/graphql/models.js
+++ b/api/graphql/models.js
@@ -25,11 +25,16 @@ export default function models (userId, isAdmin) {
         'bio',
         'updated_at'
       ],
-      relations: ['communities', 'posts'],
+      relations: ['communities', 'posts', 'memberships'],
       getters: {
         hasDevice: u => u.hasDevice()
-      },
-      filter: relation => relation
+      }
+    },
+
+    communities_users: {
+      model: Membership,
+      attributes: ['created_at', 'role', 'last_viewed_at'],
+      relations: ['community']
     },
 
     users: {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -9,7 +9,9 @@ type Me {
   url: String
   hasDevice: Boolean
   memberships(first: Int, cursor: ID, order: String): [Membership]
+  membershipsTotal: Int
   posts(first: Int, cursor: ID, order: String): [Post]
+  postsTotal: Int
 }
 
 type Person {
@@ -17,6 +19,7 @@ type Person {
   name: String
   avatarUrl: String
   posts(first: Int, cursor: ID, order: String): [Post]
+  postsTotal: Int
 }
 
 type Membership {
@@ -32,8 +35,8 @@ type Community {
   name: String
   slug: String
   createdAt: String
-  memberships(first: Int, cursor: ID, order: String): [Membership]
   members(first: Int, cursor: ID, order: String): [Person]
+  membersTotal: Int
   popularSkills(first: Int): [String]
   memberCount: Int
   postCount: Int
@@ -46,7 +49,9 @@ type Post {
   createdAt: String
   creator: Person
   followers(first: Int, cursor: ID, order: String): [Person]
+  followersTotal: Int
   communities(first: Int, cursor: ID, order: String): [Community]
+  communitiesTotal: Int
 }
 
 type Query {

--- a/api/graphql/util/applyPagination.js
+++ b/api/graphql/util/applyPagination.js
@@ -1,9 +1,16 @@
-export default function applyPagination (query, { first, cursor, order, column = 'id' }) {
+import { countTotal } from '../../../lib/util/knex'
+
+export const PAGINATION_TOTAL_COLUMN_NAME = '__total'
+
+export default function applyPagination (query, tableName, { first, cursor, order, column = 'id' }) {
   query = query.orderBy(column, order)
-  if (first) query = query.limit(first)
+  if (first) {
+    query = query.limit(first)
+    query = countTotal(query, tableName, PAGINATION_TOTAL_COLUMN_NAME)
+  }
   if (cursor) {
     const op = order === 'asc' ? '>' : '<'
-    query = query.where(column, op, cursor)
+    query = query.where(`${tableName}.${column}`, op, cursor)
   }
   return query
 }


### PR DESCRIPTION
So I was looking into the pagination bug for direct message threads, and started considering rewriting that code to use GraphQL, which uncovered the fact that I hadn't yet implemented a key part of pagination: getting the total number of results for a given query, so the client knows whether it's at the end of the result set yet.

The total number of results is not straightforward to add to the API as it currently is, because it's a property of the whole set of results, not any one instance.

The way this is handled by Relay is to add another level of indirection: instead of

```graphql
me {
  memberships(first: 3) {
    community {
      name
    }
  }
}
```

you might have

```graphql
me {
  memberships(first: 3) {
    edges {
      node {
        name
    }
    pageInfo {
      hasNextPage
    }
  }
}
```
(see the [spec docs](http://facebook.github.io/relay/graphql/connections.htm))

I wasn't prepared to go in that direction, so what I've done in this PR instead is:

```graphql
me {
  memberships(first: 3) {
    community {
      name
    }
  }
  membershipsTotal
}
```
where `membershipsTotal` is linked to whatever query parameters you used in `memberships` and does not run the query twice. Doesn't add any additional nesting and uses an easy-to-understand naming convention.

Opinions welcome.