### PR TITLE
pushing new threads over websockets fix

### DIFF
--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -140,7 +140,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
   pushMessageToSockets: function (message, userIds) {
     var postId = this.id
     const excludingSender = userIds.filter(id => id !== message.user_id.toString())
-    if (this.get('num_comments') === 1) {
+    if (this.get('num_comments') === 0) {
       return Promise.map(excludingSender, id => this.pushSelfToSocket(id))
     } else {
       return Promise.map(excludingSender, id =>


### PR DESCRIPTION
this was because previously the comment count got incremented before the websockets notification was sent,
and in the refactor done at that time it was moved to after the websocket event, which is why we now
check 'num_comments' for a 0 value instead of a 1
https://github.com/Hylozoic/hylo-node/blob/761a8ee7537990ef448087490bdf84ecd15d20ff/api/models/comment/createAndPresentComment.js