### PR TITLE
fix realtime comments for posts

### DIFF
--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -133,8 +133,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
 
   pushCommentToSockets: function (comment) {
     var postId = this.id
-    const parent_post_id = this.get('parent_post_id')
-    return pushToSockets(`posts/${postId}`, 'commentAdded', {comment, parent_post_id})
+    return pushToSockets(`posts/${postId}`, 'commentAdded', {comment})
   },
 
   pushMessageToSockets: function (message, userIds) {


### PR DESCRIPTION
there's no need, as far as I can tell, for this parent_post_id to be sent down. I've taken it out not because it was technically a bug on the backend as on the frontend, but because the fix on the frontend makes passing it extraneous

goes with https://github.com/Hylozoic/hylo-redux/pull/292