### PR TITLE
allow different GraphQL schema types to point to the same table

### DIFF
--- a/api/graphql/index.js
+++ b/api/graphql/index.js
@@ -14,16 +14,16 @@ function createSchema (userId, isAdmin) {
 
   const allResolvers = Object.assign({
     Query: {
-      me: () => fetchOne('me', userId),
+      me: () => fetchOne('Me', userId),
       community: (root, { id, slug }) => // you can specify id or slug, but not both
-        fetchOne('communities', slug || id, slug ? 'slug' : 'id'),
-      person: (root, { id }) => fetchOne('users', id)
+        fetchOne('Community', slug || id, slug ? 'slug' : 'id'),
+      person: (root, { id }) => fetchOne('User', id)
     },
     Mutation: {
       updateMe: (root, { changes }) =>
-        updateMe(userId, changes).then(() => fetchOne('me', userId)),
+        updateMe(userId, changes).then(() => fetchOne('Me', userId)),
       createPost: (root, { data }) =>
-        createPost(userId, data).then(post => fetchOne('posts', post.id))
+        createPost(userId, data).then(post => fetchOne('Post', post.id))
     },
 
     FeedItemContent: {

--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -145,7 +145,7 @@ export default function makeModels (userId, isAdmin) {
       model: Post,
       attributes: ['id', 'created_at', 'updated_at'],
       relations: [
-        'followers',
+        {followers: {alias: 'participants'}},
         {comments: {alias: 'messages', typename: 'Message'}}
       ]
     },

--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -147,11 +147,7 @@ export default function makeModels (userId, isAdmin) {
       relations: [
         'followers',
         {comments: {alias: 'messages', typename: 'Message'}}
-      ],
-      filter: nonAdminFilter(q => {
-        q.where('posts.id', 'in',
-          Follow.query().select('post_id').where('user_id', userId))
-      })
+      ]
     },
 
     Message: {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -14,6 +14,8 @@ type Me {
   communitiesTotal: Int
   posts(first: Int, cursor: ID, order: String): [Post]
   postsTotal: Int
+  messageThreads(first: Int, cursor: ID, order: String): [MessageThread]
+  messageThreadsTotal: Int
   updatedAt: String
 }
 
@@ -40,7 +42,7 @@ type Community {
   slug: String
   createdAt: String
   avatarUrl: String
-  bannerUrl: String  
+  bannerUrl: String
   members(first: Int, cursor: ID, order: String): [Person]
   membersTotal: Int
   popularSkills(first: Int): [String]
@@ -94,6 +96,23 @@ type Comment {
   creator: Person
   createdAt: String
   createdFrom: String
+}
+
+type MessageThread {
+  id: ID
+  createdAt: String
+  updatedAt: String
+  followers(first: Int, cursor: ID, order: String): [Person]
+  followersTotal: Int
+  messages(first: Int, cursor: ID, order: String): [Message]
+  messagesTotal: Int
+}
+
+type Message {
+  id: ID
+  text: String
+  creator: Person
+  createdAt: String
 }
 
 type Query {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -102,8 +102,8 @@ type MessageThread {
   id: ID
   createdAt: String
   updatedAt: String
-  followers(first: Int, cursor: ID, order: String): [Person]
-  followersTotal: Int
+  participants(first: Int, cursor: ID, order: String): [Person]
+  participantsTotal: Int
   messages(first: Int, cursor: ID, order: String): [Message]
   messagesTotal: Int
 }

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -61,6 +61,11 @@ module.exports = bookshelf.Model.extend(merge({
     }))
   },
 
+  messageThreads: function () {
+    return this.belongsToMany(Post).through(Follow)
+    .query(q => q.where({type: Post.Type.THREAD, active: true}))
+  },
+
   eventsRespondedTo: function () {
     return this.belongsToMany(Post).through(EventResponse)
   },

--- a/lib/graphql-bookshelf-bridge/fetcher.js
+++ b/lib/graphql-bookshelf-bridge/fetcher.js
@@ -1,5 +1,6 @@
 import applyPagination from './util/applyPagination'
 import initDataLoaders from './util/initDataLoaders'
+import { toPairs } from 'lodash'
 
 export default class Fetcher {
   constructor (models) {
@@ -7,16 +8,17 @@ export default class Fetcher {
     this.loaders = initDataLoaders(models)
   }
 
-  fetchRelation (relation, paginationOpts, tap) {
+  fetchRelation (relation, typename, paginationOpts, tap) {
     const { targetTableName, type, parentFk } = relation.relatedData
-    const loader = this.loaders[targetTableName]
+    if (!typename) typename = this._getTypenameFromTableName(targetTableName)
+    const loader = this.loaders[typename]
 
     if (type === 'belongsTo') {
       if (!parentFk) return Promise.resolve()
       return loader.load(parentFk)
     }
 
-    const relationSpec = this._getModel(targetTableName)
+    const relationSpec = this._getModel(typename)
     if (relationSpec.filter) relation = relationSpec.filter(relation)
 
     return this.loaders.queries.load(relation.query(q => {
@@ -30,21 +32,40 @@ export default class Fetcher {
     })
   }
 
-  fetchOne (tableName, id, idColumn = 'id') {
-    const { model, filter } = this._getModel(tableName)
+  fetchOne (typename, id, idColumn = 'id') {
+    const { model, filter } = this._getModel(typename)
     let query = model.where(idColumn, id)
     if (filter) query = filter(query)
     return this.loaders.queries.load(query).then(instance => {
       if (!instance) return
-      this.loaders[tableName].prime(instance.id, instance)
+      this.loaders[typename].prime(instance.id, instance)
       return instance
     })
   }
 
-  _getModel (tableName) {
-    if (!this.models[tableName]) {
-      throw new Error(`missing model definition for ${tableName}`)
+  _getModel (typename) {
+    if (!this.models[typename]) {
+      throw new Error(`missing model definition for ${typename}`)
     }
-    return this.models[tableName]
+    return this.models[typename]
+  }
+
+  _getTypenameFromTableName (tableName) {
+    // TODO cache this
+    const matches = toPairs(this.models)
+    .filter(([typename, spec]) => spec.model.collection().tableName() === tableName)
+
+    if (matches.length > 1) {
+      const defaultTypeForTable = matches.find(([typename, spec]) => spec.isDefaultTypeForTable)
+      if (defaultTypeForTable) return defaultTypeForTable[0]
+
+      throw new Error(`tableName "${tableName}" is ambiguous: ${matches.map(x => x[0]).join(', ')}`)
+    }
+
+    if (matches.length === 0) {
+      throw new Error(`tableName "${tableName}" doesn't match any type`)
+    }
+
+    return matches[0][0]
   }
 }

--- a/lib/graphql-bookshelf-bridge/makeResolvers.js
+++ b/lib/graphql-bookshelf-bridge/makeResolvers.js
@@ -3,12 +3,12 @@ import EventEmitter from 'events'
 import { PAGINATION_TOTAL_COLUMN_NAME } from './util/applyPagination'
 
 export default function makeResolvers (models, fetcher) {
-  return transform(models, (result, spec, name) => {
-    result[spec.typename] = createResolverForModel(name, spec, fetcher)
+  return transform(models, (result, spec, typename) => {
+    result[typename] = createResolverForModel(typename, spec, fetcher)
   }, {})
 }
 
-function createResolverForModel (name, spec, fetcher) {
+function createResolverForModel (typename, spec, fetcher) {
   const { attributes, getters, relations, model } = spec
 
   return Object.assign(
@@ -21,20 +21,37 @@ function createResolverForModel (name, spec, fetcher) {
     }, {}),
 
     transform(relations, (result, attr) => {
-      const [ graphqlName, bookshelfName ] = typeof attr === 'string'
-        ? [attr, attr] : toPairs(attr)[0]
+      var graphqlName, bookshelfName, typename
+
+      if (typeof attr === 'string') {
+        graphqlName = attr
+        bookshelfName = attr
+      } else {
+        const [ name, opts ] = toPairs(attr)[0]
+        bookshelfName = name
+
+        // relations can be aliased: in your model definition, you can write
+        // e.g. `relations: [{users: {alias: 'members'}}]` to map `members` in
+        // your GraphQL schema to the `users` Bookshelf relation.
+        graphqlName = opts.alias || name
+
+        // this must be set when a relation's Bookshelf model is backing more
+        // than one GraphQL schema type.
+        typename = opts.typename
+      }
 
       const emitterName = `__${graphqlName}__total_emitter`
 
       result[graphqlName] = (instance, { first, cursor, order }) => {
         instance[emitterName] = new EventEmitter()
         const relation = instance[bookshelfName]()
-        return fetcher.fetchRelation(relation, {first, cursor, order}, instances => {
-          const total = instances.length > 0
-            ? instances.first().get(PAGINATION_TOTAL_COLUMN_NAME)
-            : null
-          instance[emitterName].emit('hasTotal', total)
-        })
+        return fetcher.fetchRelation(relation, typename, {first, cursor, order},
+          instances => {
+            const total = instances.length > 0
+              ? instances.first().get(PAGINATION_TOTAL_COLUMN_NAME)
+              : null
+            instance[emitterName].emit('hasTotal', total)
+          })
       }
 
       if (model.forge()[bookshelfName]().relatedData.type !== 'belongsTo') {

--- a/lib/graphql-bookshelf-bridge/util/initDataLoaders.js
+++ b/lib/graphql-bookshelf-bridge/util/initDataLoaders.js
@@ -7,8 +7,8 @@ import uniqueQueryId from './uniqueQueryId'
 export default function initDataLoaders (spec) {
   const loaders = {}
 
-  forIn(spec, ({ model }, name) => {
-    loaders[name] = new DataLoader(ids => {
+  forIn(spec, ({ model }, typename) => {
+    loaders[typename] = new DataLoader(ids => {
       return model.where('id', 'in', ids).fetchAll()
       .then(objects =>
         // ensure that the order of objects matches the order of ids

--- a/test/api/graphql/index.test.js
+++ b/test/api/graphql/index.test.js
@@ -122,9 +122,11 @@ describe('graphql request handler', () => {
                   name
                 }
               }
+              commentsTotal
               followers {
                 name
               }
+              followersTotal
             }
             messageThreads {
               id
@@ -134,9 +136,11 @@ describe('graphql request handler', () => {
                   name
                 }
               }
-              followers {
+              messagesTotal
+              participants {
                 name
               }
+              participantsTotal
             }
           }
         }`
@@ -173,11 +177,13 @@ describe('graphql request handler', () => {
                       }
                     }
                   ],
+                  commentsTotal: 1,
                   followers: [
                     {
                       name: user2.get('name')
                     }
-                  ]
+                  ],
+                  followersTotal: 1
                 }
               ],
               messageThreads: [
@@ -191,14 +197,16 @@ describe('graphql request handler', () => {
                       }
                     }
                   ],
-                  followers: [
+                  messagesTotal: 1,
+                  participants: [
                     {
                       name: user.get('name')
                     },
                     {
                       name: user2.get('name')
                     }
-                  ]
+                  ],
+                  participantsTotal: 2
                 }
               ]
             }

--- a/test/api/graphql/index.test.js
+++ b/test/api/graphql/index.test.js
@@ -7,12 +7,28 @@ describe('graphql request handler', () => {
 
   before(() => {
     handler = createRequestHandler()
-    req = factories.mock.request()
-    res = factories.mock.response()
 
-    Object.assign(req, {
-      method: 'POST',
-      body: {
+    user = factories.user()
+    community = factories.community()
+    post = factories.post()
+    return Promise.all([user.save(), community.save()])
+    .then(() => post.save({user_id: user.id}))
+    .then(() => Promise.all([
+      community.posts().attach(post),
+      community.users().attach({user_id: user.id, active: true})
+    ]))
+  })
+
+  beforeEach(() => {
+    req = factories.mock.request()
+    req.method = 'POST'
+    req.session = {userId: user.id}
+    res = factories.mock.response()
+  })
+
+  describe('with a simple query', () => {
+    beforeEach(() => {
+      req.body = {
         query: `{
           me {
             name
@@ -32,46 +48,162 @@ describe('graphql request handler', () => {
       }
     })
 
-    user = factories.user()
-    community = factories.community()
-    post = factories.post()
-    return Promise.all([user.save(), community.save()])
-    .then(() => {
-      req.session = {userId: user.id}
-      return post.save({user_id: user.id})
-    })
-    .then(() => Promise.all([
-      community.posts().attach(post.id),
-      community.users().attach({user_id: user.id, active: true})
-    ]))
-  })
-
-  it('can handle a simple query', () => {
-    return handler(req, res).then(() => {
-      expect(res.body).to.exist
-      expect(JSON.parse(res.body)).to.deep.equal({
-        data: {
-          me: {
-            name: user.get('name'),
-            memberships: [
-              {
-                community: {
-                  name: community.get('name')
-                }
-              }
-            ],
-            posts: [
-              {
-                title: post.get('name'),
-                communities: [
-                  {
+    it('responds as expected', () => {
+      return handler(req, res).then(() => {
+        expect(res.body).to.exist
+        expect(JSON.parse(res.body)).to.deep.equal({
+          data: {
+            me: {
+              name: user.get('name'),
+              memberships: [
+                {
+                  community: {
                     name: community.get('name')
                   }
-                ]
-              }
-            ]
+                }
+              ],
+              posts: [
+                {
+                  title: post.get('name'),
+                  communities: [
+                    {
+                      name: community.get('name')
+                    }
+                  ]
+                }
+              ]
+            }
           }
-        }
+        })
+      })
+    })
+  })
+
+  describe('with a complex query', () => {
+    var user2, thread, comment, message
+
+    before(() => {
+      user2 = factories.user()
+      thread = factories.post({type: Post.Type.THREAD})
+
+      return Promise.all([user2.save(), thread.save()])
+      .then(() => {
+        comment = factories.comment({post_id: post.id, user_id: user2.id})
+        message = factories.comment({post_id: thread.id, user_id: user2.id})
+        return Promise.all([
+          comment.save(),
+          message.save(),
+          community.users().attach({user_id: user2.id, active: true}),
+          post.followers().attach(user2),
+          thread.followers().attach(user),
+          thread.followers().attach(user2)
+        ])
+      })
+    })
+
+    beforeEach(() => {
+      req.body = {
+        query: `{
+          me {
+            name
+            memberships {
+              community {
+                name
+              }
+            }
+            posts {
+              title
+              communities {
+                name
+              }
+              comments {
+                text
+                creator {
+                  name
+                }
+              }
+              followers {
+                name
+              }
+            }
+            messageThreads {
+              id
+              messages {
+                text
+                creator {
+                  name
+                }
+              }
+              followers {
+                name
+              }
+            }
+          }
+        }`
+      }
+    })
+
+    it('responds as expected', () => {
+      return handler(req, res).then(() => {
+        expect(res.body).to.exist
+        expect(JSON.parse(res.body)).to.deep.equal({
+          data: {
+            me: {
+              name: user.get('name'),
+              memberships: [
+                {
+                  community: {
+                    name: community.get('name')
+                  }
+                }
+              ],
+              posts: [
+                {
+                  title: post.get('name'),
+                  communities: [
+                    {
+                      name: community.get('name')
+                    }
+                  ],
+                  comments: [
+                    {
+                      text: comment.get('text'),
+                      creator: {
+                        name: user2.get('name')
+                      }
+                    }
+                  ],
+                  followers: [
+                    {
+                      name: user2.get('name')
+                    }
+                  ]
+                }
+              ],
+              messageThreads: [
+                {
+                  id: thread.id,
+                  messages: [
+                    {
+                      text: message.get('text'),
+                      creator: {
+                        name: user2.get('name')
+                      }
+                    }
+                  ],
+                  followers: [
+                    {
+                      name: user.get('name')
+                    },
+                    {
+                      name: user2.get('name')
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        })
       })
     })
   })


### PR DESCRIPTION
This PR extends the graphql-bookshelf bridge to allow multiple different GraphQL types to be backed by the same Bookshelf models.

It also uses this to add MessageThread and Message to the GraphQL schema, which are backed by Bookshelf models Post and Comment respectively.

The syntax for model specs (the output of `makeModels`) changes to support this in a few ways, all of which can be seen in the diffs. Overall, the purpose of these changes is for disambiguation: if multiple GraphQL types point to the same Bookshelf model, at the time when we have a Bookshelf model and need to map it back to a GraphQL type, we need to know which one to map it back to.

1. The top-level keys are now GraphQL schema type names, not database table names.

2. The syntax for aliases in `relations` changes:
    ```js
    // old
    {
      relations: [
        {creator: 'user'}
      ]
    }
    // new
    {
      relations: [
        {user: {alias: 'creator'}}
      ]
    }    
    ```

3. The change above was made in order to accommodate a new `typename` parameter in `relations`, which specifies the type name associated with a relation:
    ```js
    {
      relations: [
        {comments: {alias: 'messages', typename: 'Message'}}
      ]
    }
    ```

4. Since many different types have relations to e.g. `Post`, I added a shorthand for declaring that a GraphQL type should be used as the default for a bookshelf model, rather than repeatedly specify the same `typename`. This is the `isDefaultTypeForTable: true` property that was added to `Post`, `Person`, and `Comment`.