### PR TITLE
Get parent post from comment

### DIFF
--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -144,7 +144,7 @@ export default function makeModels (userId, isAdmin) {
         'created_at'
       ],
       relations: [
-        {post: {alias: 'post'}},
+        'post',
         {user: {alias: 'creator'}}
       ],
       filter: nonAdminFilter(q => {

--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -144,6 +144,7 @@ export default function makeModels (userId, isAdmin) {
         'created_at'
       ],
       relations: [
+        {post: {alias: 'post'}},
         {user: {alias: 'creator'}}
       ],
       filter: nonAdminFilter(q => {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -110,6 +110,7 @@ type Comment {
   id: ID
   text: String
   creator: Person
+  post: Post
   createdAt: String
   createdFrom: String
 }


### PR DESCRIPTION
Yet another addition! This one is to grab the post for a comment so we can display its name (and link to its id) in a comment card on the member profile overview.