### PR TITLE
add community topics

### DIFF
--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -143,7 +143,8 @@ export default function makeModels (userId, isAdmin) {
       ],
       relations: [
         {moderators: {querySet: true}},
-        {tagFollows: {querySet: true, alias: 'topicSubscriptions'}}
+        {tagFollows: {querySet: true, alias: 'topicSubscriptions'}},
+        {communityTags: {querySet: true, alias: 'communityTopics'}}
       ],
       getters: {
         popularSkills: (c, { first }) => c.popularSkills(first),
@@ -256,9 +257,26 @@ export default function makeModels (userId, isAdmin) {
       })
     },
 
+    CommunityTopic: {
+      model: CommunityTag,
+      attributes: ['id'],
+      getters: {
+        postsTotal: ct => CommunityTag.taggedPostCount(ct.get('community_id'), ct.get('tag_id')),
+        followersTotal: ct => Tag.followersCount(ct.get('tag_id'), ct.get('community_id'))
+      },
+      relations: [
+        'community',
+        {tag: {alias: 'topic'}}
+      ]
+    },
+
     Topic: {
       model: Tag,
-      attributes: ['id', 'name']
+      attributes: ['id', 'name'],
+      getters: {
+        postsTotal: t => Tag.taggedPostCount(t.id),
+        followersTotal: t => Tag.followersCount(t.id)
+      }
     }
   }
 }

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -37,9 +37,25 @@ type TopicSubscription {
   newPostCount: Int
 }
 
+type CommunityTopicQuerySet {
+  total: Int
+  hasMore: Boolean
+  items: [CommunityTopic]
+}
+
+type CommunityTopic {
+  id: ID
+  topic: Topic
+  community: Community
+  postsTotal: Int
+  followersTotal: Int
+}
+
 type Topic {
   id: ID
   name: String
+  postsTotal: Int
+  followersTotal: Int
 }
 
 type Person {
@@ -102,6 +118,11 @@ type Community {
     order: String,
     offset: Int
   ): TopicSubscriptionQuerySet
+  communityTopics(
+    first: Int,
+    order: String,
+    offset: Int
+  ): CommunityTopicQuerySet
 }
 
 type PersonQuerySet {

--- a/api/models/Community.js
+++ b/api/models/Community.js
@@ -60,6 +60,10 @@ module.exports = bookshelf.Model.extend(merge({
     return this.belongsToMany(Tag).through(CommunityTag).withPivot(['user_id', 'description'])
   },
 
+  communityTags: function () {
+    return this.hasMany(CommunityTag)
+  },
+
   comments: function () {
     var communityId = this.id
     return Comment.collection().query(q => {

--- a/api/models/CommunityTag.js
+++ b/api/models/CommunityTag.js
@@ -22,7 +22,9 @@ module.exports = bookshelf.Model.extend({
 
   taggedPostCount (communityId, tagId) {
     return bookshelf.knex('posts_tags')
+    .join('posts', 'posts.id', 'posts_tags.post_id')
     .join('communities_posts', 'communities_posts.post_id', 'posts_tags.post_id')
+    .where('posts.active', true)
     .where({community_id: communityId, tag_id: tagId})
     .count()
     .then(rows => Number(rows[0].count))

--- a/api/models/Tag.js
+++ b/api/models/Tag.js
@@ -294,6 +294,24 @@ module.exports = bookshelf.Model.extend({
     })
   },
 
+  taggedPostCount: tagId => {
+    return bookshelf.knex('posts_tags')
+    .where({tag_id: tagId})
+    .count()
+    .then(rows => Number(rows[0].count))
+  },
+
+  followersCount: (tagId, communityId) => {
+    const query = communityId ? {
+      community_id: communityId,
+      tag_id: tagId
+    } : {tag_id: tagId}
+    return bookshelf.knex('tag_follows')
+    .where(query)
+    .count()
+    .then(rows => Number(rows[0].count))
+  },
+
   nonexistent: (names, communityIds) => {
     if (names.length === 0 || !communityIds || communityIds.length === 0) return Promise.resolve({})
 

--- a/api/models/Tag.js
+++ b/api/models/Tag.js
@@ -296,6 +296,8 @@ module.exports = bookshelf.Model.extend({
 
   taggedPostCount: tagId => {
     return bookshelf.knex('posts_tags')
+    .join('posts', 'posts.id', 'posts_tags.post_id')
+    .where('posts.active', true)
     .where({tag_id: tagId})
     .count()
     .then(rows => Number(rows[0].count))


### PR DESCRIPTION
so this PR makes it so that if you're interested in the TOTAL number of posts for a topic, look at the Topic itself, and grab `postsTotal` off it, but if you're interested in the total number of posts for a topic within a community, grab it off of the CommunityTopic using `postsTotal`