### PR TITLE
Equalises knex_migrations with directory

### DIFF
--- a/migrations/scripts/updateMigrationsTable.js
+++ b/migrations/scripts/updateMigrationsTable.js
@@ -1,0 +1,15 @@
+const environment = process.env.NODE_ENV || 'development'
+const config = require('../../knexfile')[environment]
+const knex = require('knex')(config)
+const fs = require('fs')
+const path = require('path')
+
+console.info('Attempting to remove outdated migration filenames from database...')
+const migrations = fs.readdirSync(path.join(__dirname, '..'))
+  .filter(f => f.slice(-3) === '.js')
+knex('knex_migrations')
+  .whereNotIn('name', migrations)
+  .del()
+  .then(n => console.info(`...${n} rows affected.`))
+  .then(() => knex.destroy())
+  .catch(console.error)

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "dev": "nf -j Procfile.dev -p 3001 start -t 1000",
     "test": "./node_modules/.bin/mocha -r test/setup/core --compilers js:babel-register",
     "cover": "./node_modules/.bin/nyc --reporter=lcov ./node_modules/.bin/_mocha --compilers js:babel-register -R dot",
-    "knex": "knex"
+    "knex": "knex",
+    "update-migrations": "node ./migrations/scripts/updateMigrationsTable"
   },
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
Obtain a directory listing of `./migrations`, and remove everything in `knex_migrations` which isn't one of those files. To run: `npm run update-migrations`.

This is to address the situation where an existing developer has a couple of hundred migrations in their database, and we have removed all but the 2017 migrations from the directory. Knex will complain if any files are missing from `knex_migrations`.