### PR TITLE
Make tags.id bigint

### DIFF
--- a/api/services/FullTextSearch.js
+++ b/api/services/FullTextSearch.js
@@ -4,13 +4,13 @@ const tableName = 'search_index'
 const columnName = 'document'
 const defaultLang = 'english'
 
-const raw = str => bookshelf.knex.raw(str)
+const raw = (str, knex = bookshelf.knex) => knex.raw(str)
 
-const dropView = () => raw(`drop materialized view ${tableName}`)
+const dropView = knex => raw(`drop materialized view ${tableName}`, knex)
 
 const refreshView = () => raw(`refresh materialized view ${tableName}`)
 
-const createView = lang => {
+const createView = (lang, knex) => {
   if (!lang) lang = defaultLang
   var wv = (column, weight) =>
     `setweight(to_tsvector('${lang}', ${column}), '${weight}')`
@@ -49,9 +49,9 @@ const createView = lang => {
     from comments c
     join users u on u.id = c.user_id
     where c.active = true and u.active = true
-  )`)
+  )`, knex)
   .then(() => raw(`create index idx_fts_search on ${tableName}
-    using gin(${columnName})`))
+    using gin(${columnName})`, knex))
 }
 
 const search = (opts) => {

--- a/migrations/20170519141924_tags-id-biginteger.js
+++ b/migrations/20170519141924_tags-id-biginteger.js
@@ -1,0 +1,14 @@
+require('babel-register')
+const FullTextSearch = require('../api/services/FullTextSearch')
+
+exports.up = function (knex) {
+  return FullTextSearch.dropView(knex)
+    .then(() => knex.raw('ALTER TABLE tags ALTER COLUMN id TYPE bigint'))
+    .then(() => FullTextSearch.createView(null, knex))
+}
+
+exports.down = function (knex) {
+  return FullTextSearch.dropView(knex)
+    .then(() => knex.raw('ALTER TABLE tags ALTER COLUMN id TYPE integer'))
+    .then(() => FullTextSearch.createView(null, knex))
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -959,7 +959,7 @@ CREATE SEQUENCE skill_seq
 --
 
 CREATE TABLE tags (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name character varying(255) NOT NULL,
     created_at timestamp with time zone,
     updated_at timestamp with time zone

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -2011,7 +2011,7 @@ CREATE INDEX ix_vote_user_13 ON votes USING btree (user_id);
 --
 
 ALTER TABLE ONLY activities
-    ADD CONSTRAINT activities_contribution_id_foreign FOREIGN KEY (contribution_id) REFERENCES contributions(id);
+    ADD CONSTRAINT activities_contribution_id_foreign FOREIGN KEY (contribution_id) REFERENCES contributions(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2019,7 +2019,7 @@ ALTER TABLE ONLY activities
 --
 
 ALTER TABLE ONLY activities
-    ADD CONSTRAINT activities_parent_comment_id_foreign FOREIGN KEY (parent_comment_id) REFERENCES comments(id);
+    ADD CONSTRAINT activities_parent_comment_id_foreign FOREIGN KEY (parent_comment_id) REFERENCES comments(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2043,7 +2043,7 @@ ALTER TABLE ONLY activities
 --
 
 ALTER TABLE ONLY activities
-    ADD CONSTRAINT activity_community_id_foreign FOREIGN KEY (community_id) REFERENCES communities(id);
+    ADD CONSTRAINT activity_community_id_foreign FOREIGN KEY (community_id) REFERENCES communities(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2067,7 +2067,7 @@ ALTER TABLE ONLY activities
 --
 
 ALTER TABLE ONLY comments
-    ADD CONSTRAINT comments_comment_id_foreign FOREIGN KEY (comment_id) REFERENCES comments(id);
+    ADD CONSTRAINT comments_comment_id_foreign FOREIGN KEY (comment_id) REFERENCES comments(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2099,7 +2099,7 @@ ALTER TABLE ONLY communities_tags
 --
 
 ALTER TABLE ONLY communities_tags
-    ADD CONSTRAINT communities_tags_owner_id_foreign FOREIGN KEY (user_id) REFERENCES users(id);
+    ADD CONSTRAINT communities_tags_owner_id_foreign FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2115,7 +2115,7 @@ ALTER TABLE ONLY communities_tags
 --
 
 ALTER TABLE ONLY community_invites
-    ADD CONSTRAINT community_invite_tag_id_foreign FOREIGN KEY (tag_id) REFERENCES tags(id);
+    ADD CONSTRAINT community_invite_tag_id_foreign FOREIGN KEY (tag_id) REFERENCES tags(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2147,7 +2147,7 @@ ALTER TABLE ONLY devices
 --
 
 ALTER TABLE ONLY event_responses
-    ADD CONSTRAINT event_responses_post_id_foreign FOREIGN KEY (post_id) REFERENCES posts(id);
+    ADD CONSTRAINT event_responses_post_id_foreign FOREIGN KEY (post_id) REFERENCES posts(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2155,7 +2155,7 @@ ALTER TABLE ONLY event_responses
 --
 
 ALTER TABLE ONLY event_responses
-    ADD CONSTRAINT event_responses_user_id_foreign FOREIGN KEY (user_id) REFERENCES users(id);
+    ADD CONSTRAINT event_responses_user_id_foreign FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2459,7 +2459,7 @@ ALTER TABLE ONLY posts
 --
 
 ALTER TABLE ONLY posts
-    ADD CONSTRAINT post_parent_post_id_foreign FOREIGN KEY (parent_post_id) REFERENCES posts(id);
+    ADD CONSTRAINT post_parent_post_id_foreign FOREIGN KEY (parent_post_id) REFERENCES posts(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --
@@ -2547,7 +2547,7 @@ ALTER TABLE ONLY user_connections
 --
 
 ALTER TABLE ONLY user_external_data
-    ADD CONSTRAINT user_external_data_user_id_foreign FOREIGN KEY (user_id) REFERENCES users(id);
+    ADD CONSTRAINT user_external_data_user_id_foreign FOREIGN KEY (user_id) REFERENCES users(id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --


### PR DESCRIPTION
This was a fiddly little thing. In order for it to work, I needed to provide the knex object used in migrations (which is normally set up to use a transaction for each migration I believe) to the view create/drop functions in FullTextSearch. They will use the old `bookshelf.knex` at other times.

Took me quite a long time to realise I couldn't do 
```
  .then(FullTextSearch(createView(null, knex)))
```
instead of 
```
  .then(() => FullTextSearch(createView(null, knex)))
```
Oh well, live and learn :grinning: 