### PR TITLE
first time use of findOrCreateThread would break, and so would first comment

### DIFF
--- a/api/models/comment/createAndPresentComment.js
+++ b/api/models/comment/createAndPresentComment.js
@@ -108,13 +108,13 @@ function notifySockets (comment, post) {
 }
 
 // n.b.: `message` has already been formatted for presentation
-function pushMessageToSockets (thread, message, userIds) {
+export function pushMessageToSockets (thread, message, userIds) {
   const excludingSender = userIds.filter(id => id !== message.user_id.toString())
 
   if (thread.get('num_comments') === 0) {
     return Promise.map(excludingSender, userId => {
       const opts = {withComments: 'all'}
-      return this.load(PostPresenter.relations(userId, opts))
+      return thread.load(PostPresenter.relations(userId, opts))
       .then(post => PostPresenter.present(post, userId, opts))
       .then(normalizedSinglePostResponse)
       .then(post => pushToSockets(userRoom(userId), 'newThread', post))

--- a/api/models/post/findOrCreateThread.js
+++ b/api/models/post/findOrCreateThread.js
@@ -16,7 +16,7 @@ export default function findOrCreateThread (userId, participantIds) {
   .then(post => post || createThread(userId, participantIds))
 }
 
-function createThread (userId, participantIds) {
+export function createThread (userId, participantIds) {
   return setupNewThreadAttrs(userId)
   .then(attrs => bookshelf.transaction(trx =>
     Post.create(attrs, {transacting: trx})
@@ -44,7 +44,8 @@ function setupNewThreadAttrs (userId) {
   return Promise.resolve({
     type: Post.Type.THREAD,
     visibility: Post.Visibility.DEFAULT,
-    user_id: userId
+    user_id: userId,
+    link_preview_id: null
   })
 }
 

--- a/api/models/post/findOrCreateThread.test.js
+++ b/api/models/post/findOrCreateThread.test.js
@@ -1,4 +1,4 @@
-import { validateThreadData } from './findOrCreateThread'
+import { validateThreadData, createThread } from './findOrCreateThread'
 
 describe('validateThreadData', () => {
   var user, userSharingCommunity, userNotInCommunity, inCommunity
@@ -35,5 +35,31 @@ describe('validateThreadData', () => {
   it('continue the promise chain if user shares community with all participants', () => {
     const data = {participantIds: [userSharingCommunity.id]}
     expect(validateThreadData(user.id, data)).to.respondTo('then')
+  })
+})
+
+describe('createThread', () => {
+  var user, user2, community
+
+  before(function () {
+    community = new Community({slug: 'foo3', name: 'Foo3'})
+    user = new User({name: 'Cat', email: 'catcat@b.c'})
+    user2 = new User({name: 'Meow', email: 'meowcat@b.cd'})
+    return Promise.join(
+      community.save(),
+      user.save(),
+      user2.save()
+    ).then(function () {
+      return Promise.join(
+        user.joinCommunity(community),
+        user2.joinCommunity(community)
+      )
+    })
+  })
+
+  it('creates and returns a new thread', () => {
+    createThread(user.id, [user2.id]).then(p => {
+      expect(p).to.exist
+    })
   })
 })

--- a/api/models/post/findOrCreateThread.test.js
+++ b/api/models/post/findOrCreateThread.test.js
@@ -58,7 +58,7 @@ describe('createThread', () => {
   })
 
   it('creates and returns a new thread', () => {
-    createThread(user.id, [user2.id]).then(p => {
+    return createThread(user.id, [user2.id]).then(p => {
       expect(p).to.exist
     })
   })

--- a/api/services/Websockets.js
+++ b/api/services/Websockets.js
@@ -11,7 +11,7 @@ export function pushToSockets (room, messageType, payload, socketToExclude) {
     throw new Error(`unknown message type: ${messageType}`)
   }
 
-  if (process.env.NODE_ENV === 'test') return Promise.resolve()
+  if (process.env.NODE_ENV === 'test') return Promise.resolve({room, messageType, payload})
   sails.sockets.broadcast(room, messageType, payload, socketToExclude)
   return Promise.resolve()
 }

--- a/test/unit/models/comment/createAndPresentComment.test.js
+++ b/test/unit/models/comment/createAndPresentComment.test.js
@@ -1,6 +1,10 @@
-import {
-  validateCommentCreateData
+import createAndPresentComment, {
+  validateCommentCreateData,
+  pushMessageToSockets
 } from '../../../../api/models/comment/createAndPresentComment'
+import {
+  createThread
+} from '../../../../api/models/post/findOrCreateThread'
 import setup from '../../../setup'
 import factories from '../../../setup/factories'
 
@@ -35,4 +39,54 @@ describe('comment/createAndPresentComment', () => {
       expect(validateCommentCreateData(user.id, data)).to.respondTo('then')
     })
   })
+
+  describe('pushMessageToSockets', () => {
+    var user, user2, thread
+
+    before(function () {
+      user = new User({name: 'Oo Joy', email: 'oojoy@b.c'})
+      user2 = new User({name: 'Oo Boy', email: 'ooboy@c.d'})
+      return Promise.join(
+        user.save(),
+        user2.save()
+      ).then(() => {
+        return createThread(user.id, [user2.id])
+        .then(t => {
+          thread = t
+        })
+      })
+    })
+
+    it('sends newThread event if first message', () => {
+      const message = {
+        user_id: user.id
+      }
+      return pushMessageToSockets(thread, message, [user.id, user2.id])
+      .then(promises => {
+        expect(promises.length).to.equal(1)
+        const { room, messageType, payload } = promises[0]
+        expect(room).to.equal(`users/${user2.id}`)
+        expect(messageType).to.equal('newThread')
+        expect(payload.id).to.equal(thread.id)
+      })
+    })
+
+    it('sends messageAdded event if not first message', () => {
+      const message = {
+        user_id: user.id
+      }
+      thread.set({num_comments: 2})
+      return pushMessageToSockets(thread, message, [user.id, user2.id])
+      .then(promises => {
+        expect(promises.length).to.equal(1)
+        const { room, messageType, payload } = promises[0]
+        expect(room).to.equal(`users/${user2.id}`)
+        expect(messageType).to.equal('messageAdded')
+        expect(payload.postId).to.equal(thread.id)
+        expect(payload.message).to.exist
+      })
+    })
+  })
+
+
 })


### PR DESCRIPTION
this would happen when using hylo-redux... opening the modal to start a new thread, then trying to send a comment. the user feedback for it not working wasn't good/implemented

related to the calling of createAndPresentComment (at comment creation)
![screen shot 2017-06-06 at 9 06 54 pm](https://user-images.githubusercontent.com/1409121/26857908-21c33204-4afc-11e7-974c-f8532499bbfc.png)

related to the calling of findOrCreateThread
![screen shot 2017-06-06 at 9 07 04 pm](https://user-images.githubusercontent.com/1409121/26857910-240a7432-4afc-11e7-8527-b9e30d6f9dee.png)
