### PR TITLE
fixes issue where saving settings throws an error

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -120,7 +120,7 @@ module.exports = bookshelf.Model.extend(merge({
   setSanely: function (attrs) {
     const saneAttrs = omit(attrs, 'settings')
 
-    if (saneAttrs.twitter_name) {
+    if (!isEmpty(saneAttrs.twitter_name)) {
       if (saneAttrs.twitter_name.match(/^\s*$/)) {
         saneAttrs.twitter_name = null
       } else if (saneAttrs.twitter_name.match(/^@/)) {


### PR DESCRIPTION
https://trello.com/c/ZWvyEYuK/463-evo-cannot-change-name-from-settings-page