### PR TITLE
Web 35 worker error stacktraces

### DIFF
--- a/cron.js
+++ b/cron.js
@@ -85,6 +85,7 @@ skiff.lift({
     })
     .catch(function (err) {
       sails.log.error(red(err.message))
+      sails.log.error(err)
       rollbar.handleError(err, () => skiff.lower())
     })
   }

--- a/worker.js
+++ b/worker.js
@@ -52,7 +52,7 @@ var processJobs = function () {
         const error = typeof err === 'string'
           ? new Error(err)
           : (err || new Error('kue job failed without error'))
-        sails.log.error(label + error.message.red)
+        sails.log.error(label + error.message.red, error)
         rollbar.handleErrorWithPayloadData(error, data)
         done(error)
       })

--- a/worker.js
+++ b/worker.js
@@ -48,7 +48,7 @@ var processJobs = function () {
         done()
       })
       .catch(err => {
-        const data = {custom: {jobData: job.data}}
+        const data = {custom: {jobId: job.id, jobData: job.data}}
         const error = typeof err === 'string'
           ? new Error(err)
           : (err || new Error('kue job failed without error'))


### PR DESCRIPTION
@richchurcher I went through and tested this thoroughly and stacktraces appear to be spitting out correctly in all cases now.  I also added the jobId to the rollbar handling.  was there anything else you were thinking about in for this issue: https://hylozoic.atlassian.net/browse/WEB-35?