### PR TITLE
(wip) update Search.forUsers to work with skills

### DIFF
--- a/api/services/Search/forUsers.js
+++ b/api/services/Search/forUsers.js
@@ -43,10 +43,10 @@ export default function (opts) {
     }
 
     if (opts.term) {
-      qb.leftJoin('tags_users', 'tags_users.user_id', 'users.id')
-      qb.leftJoin('tags', 'tags.id', 'tags_users.tag_id')
+      qb.leftJoin('skills_users', 'skills_users.user_id', 'users.id')
+      qb.leftJoin('skills', 'skills.id', 'skills_users.skill_id')
       addTermToQueryBuilder(opts.term, qb, {
-        columns: ['users.name', 'users.bio', 'tags.name']
+        columns: ['users.name', 'users.bio', 'skills.name']
       })
     }
 


### PR DESCRIPTION
```
query ($slug: String, $first: Int, $sortBy: String, $offset: Int, $search: String) {
  network (slug: $slug) {
    id
    name
    avatarUrl
    memberCount
    members (first: $first, sortBy: $sortBy, offset: $offset, search: $search) {
      items {
        id
        name
        avatarUrl
        location
        tagline
      }
      hasMore
    }
  }
}

{
  "slug": "impact-hub-global",
  "first": 5,
  "search": "juggling"
}
```

currently this query breaks with 
`table name \"skills_users\" specified more than once`