### PR TITLE
WEB-35: Provide more debugging context on Redis errors

### DIFF
--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -315,6 +315,11 @@ module.exports = bookshelf.Model.extend({
     const redisInfo = parseRedisUrl().parse(process.env.REDIS_URL)
     const io = emitter(redisInfo)
     io.on('error', err => console.error(`Socket error on newNotification: ${err}`))
+    io.redis.on('error', err => console.error(`
+      Redis error: ${JSON.stringify(err)}
+      while attempting to send notification via socket from actor: ${JSON.stringify(actor)}
+      in community ${JSON.stringify(community)}
+    `))
     io.in(userRoom(userId)).emit('newNotification', payload)
   }
 }, {


### PR DESCRIPTION
I've been hitting my head against a brick wall trying to understand the interaction between Sails, Kue, Heroku, and Redis. I still don't feel I understand what's happening, or how to debug the problem. In the interim, to stop blocking us on this issue, I'd like to try putting a bit more logging in and see what happens when it's live for a few days. Perhaps if I stop thinking about it for awhile the answer will emerge!