### PR TITLE
MBL-77 Allow div in sanitize

### DIFF
--- a/api/models/comment/createAndPresentComment.js
+++ b/api/models/comment/createAndPresentComment.js
@@ -10,7 +10,9 @@ export function createComment (userId, data) {
 }
 
 export default function createAndPresentComment (commenterId, text, post, opts = {}) {
+  console.log('TEXT UNSANITIZED', text)
   text = sanitize(text)
+  console.log('TEXT SANITIZED', text)
   const { parentComment, returnRaw } = opts
   const isReplyToPost = !parentComment
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "graphql": "^0.8.2",
     "graphql-tools": "^0.10.1",
     "grunt": "1.0.0",
-    "hylo-utils": "Hylozoic/hylo-utils#4202b24",
+    "hylo-utils": "Hylozoic/hylo-utils#300538a",
     "image-size": "^0.3.5",
     "knex": "0.12.1",
     "kue": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,9 +3543,9 @@ https-proxy-agent@0, https-proxy-agent@^0.3.5:
     debug "2"
     extend "3"
 
-hylo-utils@Hylozoic/hylo-utils#4202b24:
-  version "1.1.0"
-  resolved "https://codeload.github.com/Hylozoic/hylo-utils/tar.gz/4202b24df757c6e3c7b505a433e654c0956517c2"
+hylo-utils@Hylozoic/hylo-utils#300538a:
+  version "1.1.1"
+  resolved "https://codeload.github.com/Hylozoic/hylo-utils/tar.gz/300538ae6e442b163862bb0ee07734a5a131c1b5"
   dependencies:
     buffer "^5.0.6"
     cheerio "^0.22.0"


### PR DESCRIPTION
As it turns out, the comment editor newline bug was twofold: `sanitize` was stripping it out in the component and in the backend. Updated `hylo-utils` again (gulp) so this is the backend part. It does definitely need complete removal of `node_modules`, `yarn cache clean` etc. It doesn't seem to need `yarn upgrade hylo-utils` though.