### PR TITLE
MBL-17 update logic for flagging content mutations to generate links on backend

### DIFF
--- a/api/graphql/mutations/index.js
+++ b/api/graphql/mutations/index.js
@@ -132,7 +132,22 @@ export function removeSkill (userId, skillIdOrName) {
   .then(() => ({success: true}))
 }
 
-export function flagInappropriateContent (userId, { category, reason, link }) {
+export function flagInappropriateContent (userId, { category, reason, linkData }) {
+  let link
+  switch (trim(linkData.type)) {
+    case 'post':
+      link = Frontend.Route.post(linkData.id, linkData.slug)
+      break
+    case 'comment':
+      link = Frontend.Route.thread(linkData.id)
+      break
+    case 'member':
+      link = Frontend.Route.profile(linkData.id)
+      break
+    default:
+      throw new Error('Invalid Link Type')
+  }
+
   return FlaggedItem.create({
     user_id: userId,
     category,

--- a/api/graphql/mutations/index.js
+++ b/api/graphql/mutations/index.js
@@ -145,7 +145,7 @@ export function flagInappropriateContent (userId, { category, reason, linkData }
       link = Frontend.Route.profile(linkData.id)
       break
     default:
-      throw new Error('Invalid Link Type')
+      return Promise.reject(new Error('Invalid Link Type'))
   }
 
   return FlaggedItem.create({

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -639,5 +639,11 @@ type SkillQuerySet {
 input InappropriateContentInput {
   category: String,
   reason: String,
-  link: String
+  linkData: LinkDataInput
+}
+
+input LinkDataInput {
+  id: ID
+  slug: String
+  type: String
 }

--- a/api/models/FlaggedItem.js
+++ b/api/models/FlaggedItem.js
@@ -28,7 +28,7 @@ module.exports = bookshelf.Model.extend({
       return Promise.reject('Unknown category.')
     }
 
-    // set reason to N/A if not required and it's empty.
+    // set reason to 'N/A' if not required (!other) and it's empty.
     if (category !== this.Category.other && isEmpty(trim(reason))) {
       reason = 'N/A'
     }
@@ -36,7 +36,7 @@ module.exports = bookshelf.Model.extend({
     const invalidReason = validateFlaggedItem.reason(reason)
     if (invalidReason) return Promise.reject(invalidReason)
 
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV !== 'development') {
       const invalidLink = validateFlaggedItem.link(link)
       if (invalidLink) return Promise.reject(invalidLink)
     }

--- a/api/models/FlaggedItem.js
+++ b/api/models/FlaggedItem.js
@@ -1,4 +1,4 @@
-import { values } from 'lodash'
+import { values, isEmpty, trim } from 'lodash'
 import { validateFlaggedItem } from 'hylo-utils/validators'
 
 module.exports = bookshelf.Model.extend({
@@ -10,6 +10,8 @@ module.exports = bookshelf.Model.extend({
 
 }, {
   Category: {
+    INAPPROPRIATE: 'inappropriate',
+    OFFENSIVE: 'offensive',
     ABUSIVE: 'abusive',
     ILLEGAL: 'illegal',
     OTHER: 'other',
@@ -18,17 +20,26 @@ module.exports = bookshelf.Model.extend({
   },
 
   create: function (attrs) {
-    const { category, link, reason } = attrs
+    const { category, link } = attrs
+
+    let { reason } = attrs
 
     if (!values(this.Category).find(c => category === c)) {
       return Promise.reject('Unknown category.')
     }
 
+    // set reason to N/A if not required and it's empty.
+    if (category !== this.Category.other && isEmpty(trim(reason))) {
+      reason = 'N/A'
+    }
+
     const invalidReason = validateFlaggedItem.reason(reason)
     if (invalidReason) return Promise.reject(invalidReason)
 
-    const invalidLink = validateFlaggedItem.link(link)
-    if (invalidLink) return Promise.reject(invalidLink)
+    if (process.env.NODE_ENV === 'production') {
+      const invalidLink = validateFlaggedItem.link(link)
+      if (invalidLink) return Promise.reject(invalidLink)
+    }
 
     return this.forge(attrs).save()
   }

--- a/api/models/FlaggedItem.js
+++ b/api/models/FlaggedItem.js
@@ -29,7 +29,7 @@ module.exports = bookshelf.Model.extend({
     }
 
     // set reason to 'N/A' if not required (!other) and it's empty.
-    if (category !== this.Category.other && isEmpty(trim(reason))) {
+    if (category !== 'other' && isEmpty(trim(reason))) {
       reason = 'N/A'
     }
 

--- a/api/services/Frontend.js
+++ b/api/services/Frontend.js
@@ -1,4 +1,4 @@
-import { isString, get, isEmpty } from 'lodash'
+import { isString, isNumber, get, isEmpty } from 'lodash'
 
 /*
 
@@ -16,6 +16,29 @@ var url = function () {
   return format.apply(null, args)
 }
 
+var getModelId = function(model) {
+  let id
+  // If it's a number, than we just passed the ID in straight
+  if (isString(model) || isNumber(model)) {
+    id = model
+  } else if (model) {
+    id = model.id
+  }
+
+  return id
+}
+
+var getSlug = function(community) {
+  let slug
+  if (isString(community)) { // In case we passed just the slug in instead of community object
+    slug = community
+  } else if (community) {
+    slug = community.slug || community.get('slug')
+  }
+
+  return slug
+}
+
 module.exports = {
   Route: {
     evo: {
@@ -29,7 +52,7 @@ module.exports = {
     root: () => url('/app'),
 
     community: function (community) {
-      return url('/c/%s', community.get('slug'))
+      return url('/c/%s', getSlug(community))
     },
 
     communitySettings: function (community) {
@@ -41,25 +64,19 @@ module.exports = {
     },
 
     profile: function (user) {
-      return url('/m/%s', user.id)
+      return url(`/m/${getModelId(user)}`)
     },
 
     post: function (post, community) {
-      let communitySlug
-
-      if (isString(community)) { // In case we passed just the slug in instead of community object
-        communitySlug = community
-      } else if (community) {
-        communitySlug = community.slug || community.get('slug')
-      }
+      let communitySlug = getSlug(community)
 
       let communityUrl = isEmpty(communitySlug) ? '/all' : `/c/${communitySlug}`
 
-      return url(`${communityUrl}/p/${post.id}`)
+      return url(`${communityUrl}/p/${getModelId(post)}`)
     },
 
     thread: function (post) {
-      return url(`/t/${post.id}`)
+      return url(`/t/${getModelId(post)}`)
     },
 
     unfollow: function (post, community) {
@@ -92,7 +109,7 @@ module.exports = {
     },
 
     invitePath: function (community) {
-      return `/c/${community.get('slug')}/join/${community.get('beta_access_code')}`
+      return `/c/${getSlug(community)}/join/${community.get('beta_access_code')}`
     }
   }
 }

--- a/test/unit/graphql/mutations/mutations.test.js
+++ b/test/unit/graphql/mutations/mutations.test.js
@@ -1,6 +1,7 @@
 import {
   addSkill,
-  removeSkill
+  removeSkill,
+  flagInappropriateContent
 } from '../../../../api/graphql/mutations'
 import root from 'root-path'
 require(root('test/setup'))
@@ -54,4 +55,98 @@ describe('mutations', () => {
       expect(skills.toJSON()).to.not.contain.a.thing.with.property('name', name)
     })
   })
+
+  it('flags inappropriate posts with valid parameters', () => {
+    let flaggedContent
+    let data = {
+      category: 'spam',
+      reason: 'my post reason',
+      linkData: {
+        id: 10,
+        type: 'post'
+      }
+    }
+
+    return flagInappropriateContent(u1.id, data)
+    .then(result => {
+      expect(result).to.have.property('success', true)
+      return FlaggedItem.where('category', 'spam').fetch()
+    })
+    .then(flaggedItem => {
+      expect(flaggedItem.toJSON()).to.have.property('reason', 'my post reason')
+    })
+  })
+
+  it('flags inappropriate content with valid parameters', () => {
+    let flaggedContent
+    let data = {
+      category: 'inappropriate',
+      reason: 'my comment reason',
+      linkData: {
+        id: 10,
+        type: 'comment'
+      }
+    }
+
+    return flagInappropriateContent(u1.id, data)
+    .then(result => {
+      expect(result).to.have.property('success', true)
+      return FlaggedItem.where('category', 'inappropriate').fetch()
+    })
+    .then(flaggedItem => {
+      expect(flaggedItem.toJSON()).to.have.property('reason', 'my comment reason')
+    })
+  })
+
+  it('flags inappropriate content with valid parameters', () => {
+    let flaggedContent
+    let data = {
+      category: 'illegal',
+      reason: 'my member reason',
+      linkData: {
+        id: 10,
+        type: 'member'
+      }
+    }
+
+    return flagInappropriateContent(u1.id, data)
+    .then(result => {
+      expect(result).to.have.property('success', true)
+      return FlaggedItem.where('category', 'illegal').fetch()
+    })
+    .then(flaggedItem => {
+      expect(flaggedItem.toJSON()).to.have.property('reason', 'my member reason')
+    })
+  })
+
+  it('fails to flag unidentified content with valid parameters', (done) => {
+    let flaggedContent
+    let data = {
+      category: 'safety',
+      reason: 'my UFO reason',
+      linkData: {
+        id: 10,
+        type: 'ufo'
+      }
+    }
+
+    expect(flagInappropriateContent(u1.id, data)).to.eventually.be.rejectedWith(Error, 'Invalid Link Type').and.notify(done)
+  })
+
+  it('fails to flag inappropriate content with type: other and no reason', (done) => {
+    let flaggedContent
+    let data = {
+      category: 'other',
+      reason: '',
+      linkData: {
+        id: 10,
+        type: 'post'
+      }
+    }
+
+    expect(flagInappropriateContent(u1.id, data)).to.eventually.be.rejected.and.notify(done)
+  })
+
+
+
 })

--- a/test/unit/graphql/mutations/mutations.test.js
+++ b/test/unit/graphql/mutations/mutations.test.js
@@ -56,7 +56,7 @@ describe('mutations', () => {
     })
   })
 
-  it('flags inappropriate posts with valid parameters', () => {
+  it('flags post with valid parameters', () => {
     let flaggedContent
     let data = {
       category: 'spam',
@@ -77,7 +77,7 @@ describe('mutations', () => {
     })
   })
 
-  it('flags inappropriate content with valid parameters', () => {
+  it('flags comment with valid parameters', () => {
     let flaggedContent
     let data = {
       category: 'inappropriate',
@@ -98,7 +98,7 @@ describe('mutations', () => {
     })
   })
 
-  it('flags inappropriate content with valid parameters', () => {
+  it('flags member with valid parameters', () => {
     let flaggedContent
     let data = {
       category: 'illegal',
@@ -116,6 +116,27 @@ describe('mutations', () => {
     })
     .then(flaggedItem => {
       expect(flaggedItem.toJSON()).to.have.property('reason', 'my member reason')
+    })
+  })
+
+  it('flags content with non-other category and empty reason', () => {
+    let flaggedContent
+    let data = {
+      category: 'abusive',
+      reason: '',
+      linkData: {
+        id: 10,
+        type: 'member'
+      }
+    }
+
+    return flagInappropriateContent(u1.id, data)
+    .then(result => {
+      expect(result).to.have.property('success', true)
+      return FlaggedItem.where('category', 'abusive').fetch()
+    })
+    .then(flaggedItem => {
+      expect(flaggedItem.toJSON()).to.have.property('reason', '')
     })
   })
 

--- a/test/unit/models/FlaggedItem.test.js
+++ b/test/unit/models/FlaggedItem.test.js
@@ -30,7 +30,7 @@ describe('FlaggedItem', () => {
     })
 
     it('rejects on a missing reason', () => {
-      const p = FlaggedItem.create(Object.assign({}, item, { reason: undefined }))
+      const p = FlaggedItem.create(Object.assign({}, item, { category: 'other', reason: undefined }))
       return expect(p).to.be.rejectedWith(/Reason must be a string/)
     })
 


### PR DESCRIPTION
This changes the logic of the flagInappropriateContent logic so that links are generated on the backend instead of passing the link from the frontend (ie: mobile or web).

The PR for the frontend is here: https://github.com/Hylozoic/HyloReactNative/pull/67
(though it's not finished yet).