### PR TITLE
MBL-81: set backend up to deliver socket updates in correct format 

### DIFF
--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -298,19 +298,30 @@ module.exports = bookshelf.Model.extend({
   },
 
   updateUserSocketRoom: function (userId) {
+    const { activity } = this.relations
     const actor = Object.assign({},
       this.actor().pick([ 'id', 'name' ]),
       { avatarUrl: this.actor().get('avatar_url') }
     )
+    const meta = activity.get('meta')
+    const action = Notification.priorityReason(meta.reasons)
     const comment = this.comment().pick([ 'id', 'text' ])
-    const community = this.relations.activity.relations.community.pick([ 'id', 'name', 'slug' ])
+    const community = activity.relations.community.pick([ 'id', 'name', 'slug' ])
+    const createdAt = activity.get('created_at').toString()
     const post = { id: this.post().id, title: this.post().get('name') }
     const payload = {
       id: '' + this.id,
-      createdAt: this.get('created_at'),
-      activity: Object.assign({},
-        this.relations.activity.pick([ 'action', 'id', 'meta', 'unread' ]),
-        { actor, comment, community, post })
+      activity: {
+        action,
+        actor,
+        comment,
+        community,
+        createdAt,
+        id: '' + this.relations.activity.id,
+        meta,
+        post,
+        unread: activity.get('unread')
+      }
     }
 
     const redisInfo = parseRedisUrl().parse(process.env.REDIS_URL)

--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -301,10 +301,8 @@ module.exports = bookshelf.Model.extend({
   updateUserSocketRoom: function (userId) {
     const { activity } = this.relations
     const { actor, comment, community, post } = activity.relations
-    const meta = activity.get('meta')
-    const action = Notification.priorityReason(meta.reasons)
+    const action = Notification.priorityReason(activity.get('meta').reasons)
 
-    const p = refineOne(post, [ 'id', 'name', 'details' ])
     const payload = {
       id: '' + this.id,
       activity: Object.assign({},
@@ -314,8 +312,11 @@ module.exports = bookshelf.Model.extend({
           actor: refineOne(actor, [ 'avatar_url', 'id', 'name' ]),
           comment: refineOne(comment, [ 'id', 'text' ]),
           community: refineOne(community, [ 'id', 'name', 'slug' ]),
-          meta,
-          post: { id: p.id, title: p.name, details: p.details }
+          post: refineOne(
+            post,
+            [ 'id', 'name', 'description' ],
+            { description: 'details', name: 'title' }
+          )
         }
       )
     }

--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -269,20 +269,21 @@ module.exports = bookshelf.Model.extend(Object.assign({
   getNewPostSocketPayload: function () {
     const { communities, linkPreview, tags, user } = this.relations
 
+    const creator = refineOne(user, [ 'id', 'name', 'avatar_url' ])
     const topics = refineMany(tags, [ 'id', 'name' ])
 
     return Object.assign({},
       refineOne(
         this,
-        [ 'created_at', 'details', 'id', 'name', 'num_votes', 'type', 'updated_at' ],
-        { 'name': 'title', 'num_votes': 'votesTotal' }
+        [ 'created_at', 'description', 'id', 'name', 'num_votes', 'type', 'updated_at' ],
+        { 'description': 'details', 'name': 'title', 'num_votes': 'votesTotal' }
       ),
       {
         // Shouldn't have commenters immediately after creation
         commenters: [],
         commentsTotal: 0,
         communities: refineMany(communities, [ 'id', 'name', 'slug' ]),
-        creator: refineOne(user, [ 'id', 'name', 'avatar_url' ]),
+        creator,
         linkPreview: refineOne(linkPreview, [ 'id', 'image_url', 'title', 'url' ]),
         topics,
 

--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -262,11 +262,11 @@ module.exports = bookshelf.Model.extend(Object.assign({
   },
 
   // Emulate the graphql request for a post in the feed so the feed can be
-  // updated via socket.
+  // updated via socket. Some fields omitted, linkPreview for example.
   // TODO: if we were in a position to avoid duplicating the graphql layer
   // here, that'd be grand.
   getNewPostSocketPayload: function () {
-    const attachments = this.relations.attachments.map(a => a.pick([
+    const attachments = this.relations.media.map(m => m.pick([
       'id', 'position', 'type', 'url'
     ]))
     const communities = this.relations.communities.map(c => c.pick([
@@ -274,87 +274,31 @@ module.exports = bookshelf.Model.extend(Object.assign({
     ]))
     const creator = this.relations.user.pick([ 'id', 'name', 'avatarUrl' ])
     const createdAt = this.get('created_at').toString()
-    // const linkPreview = this.relations.linkPreview.pick([
-    //   'id', 'imageUrl', 'title', 'url'
-    // ])
-    const topics = this.tags().map('id').map(String),
+    const topics = this.tags().map('id').map(String)
     const updatedAt = this.get('updated_at').toString()
     const votesTotal = this.get('num_votes')
 
     return Object.assign({},
       this.pick([ 'id', 'title', 'details', 'type' ]),
       {
-        // Shouldn't have commenters immediately after creation
         attachments,
+        // Shouldn't have commenters immediately after creation
         commenters: [],
         commentsTotal: 0,
         communities,
         createdAt,
         creator,
-        // linkPreview,
+        topics,
         updatedAt,
         votesTotal,
 
         // May need to retain these to avoid breaking legacy code.
         // TODO: Check if these are still required.
-        creatorId: creator.id
+        creatorId: creator.id,
+        tags: topics
       }
     )
   }
-// id
-// title
-// details
-// type
-// creator {
-//   id
-//   name
-//   avatarUrl
-// }
-// createdAt
-// updatedAt
-// commenters(first: 3) {
-//   id
-//   name
-//   avatarUrl
-// }
-// commentersTotal
-// ${withComments ? `comments(first: 10, order: "desc") {
-//   items {
-//     id
-//     text
-//     creator {
-//       id
-//       name
-//       avatarUrl
-//     }
-//     attachments {
-//       id
-//       url
-//     }
-//     createdAt
-//   }
-//   total
-//   hasMore
-// }` : ''}
-// linkPreview {
-//   id
-//   title
-//   url
-//   imageUrl
-// }
-// votesTotal
-// myVote
-// communities {
-//   id
-//   name
-//   slug
-// }
-// attachments {
-//   id
-//   position
-//   type
-//   url
-// }`
 }, EnsureLoad), {
   // Class Methods
 

--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -1,6 +1,6 @@
 /* globals LastRead, _ */
 /* eslint-disable camelcase */
-import { camelCase, filter, keys, isNull, mapKeys, omitBy, uniqBy, isEmpty, intersection } from 'lodash/fp'
+import { filter, isNull, omitBy, uniqBy, isEmpty, intersection } from 'lodash/fp'
 import { flatten } from 'lodash'
 import { postRoom, pushToSockets } from '../services/Websockets'
 import { addFollowers } from './post/util'

--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -267,15 +267,17 @@ module.exports = bookshelf.Model.extend(Object.assign({
   // TODO: if we were in a position to avoid duplicating the graphql layer
   // here, that'd be grand.
   getNewPostSocketPayload: function () {
-    const { communities, linkPreview, media, tags, user } = this.relations
+    const { communities, linkPreview, tags, user } = this.relations
 
-    const creator = refineOne(user, [ 'id', 'name', 'avatar_url' ])
     const topics = refineMany(tags, [ 'id', 'name' ])
 
     return Object.assign({},
-      refineOne(this, [ 'created_at', 'details', 'id', 'title', 'type', 'updated_at' ]),
+      refineOne(
+        this,
+        [ 'created_at', 'details', 'id', 'name', 'num_votes', 'type', 'updated_at' ],
+        { 'name': 'title', 'num_votes': 'votesTotal' }
+      ),
       {
-        attachments: refineMany(media, [ 'id', 'position', 'type', 'url' ]),
         // Shouldn't have commenters immediately after creation
         commenters: [],
         commentsTotal: 0,
@@ -283,7 +285,6 @@ module.exports = bookshelf.Model.extend(Object.assign({
         creator: refineOne(user, [ 'id', 'name', 'avatar_url' ]),
         linkPreview: refineOne(linkPreview, [ 'id', 'image_url', 'title', 'url' ]),
         topics,
-        votesTotal: this.get('num_votes'),
 
         // May need to retain these to avoid breaking legacy code.
         // TODO: Check if these are still required.

--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -259,8 +259,102 @@ module.exports = bookshelf.Model.extend(Object.assign({
   removeFromCommunity: function (idOrSlug) {
     return PostMembership.find(this.id, idOrSlug)
     .then(membership => membership.destroy())
-  }
+  },
 
+  // Emulate the graphql request for a post in the feed so the feed can be
+  // updated via socket.
+  // TODO: if we were in a position to avoid duplicating the graphql layer
+  // here, that'd be grand.
+  getNewPostSocketPayload: function () {
+    const attachments = this.relations.attachments.map(a => a.pick([
+      'id', 'position', 'type', 'url'
+    ]))
+    const communities = this.relations.communities.map(c => c.pick([
+      'id', 'name', 'slug'
+    ]))
+    const creator = this.relations.user.pick([ 'id', 'name', 'avatarUrl' ])
+    const createdAt = this.get('created_at').toString()
+    // const linkPreview = this.relations.linkPreview.pick([
+    //   'id', 'imageUrl', 'title', 'url'
+    // ])
+    const topics = this.tags().map('id').map(String),
+    const updatedAt = this.get('updated_at').toString()
+    const votesTotal = this.get('num_votes')
+
+    return Object.assign({},
+      this.pick([ 'id', 'title', 'details', 'type' ]),
+      {
+        // Shouldn't have commenters immediately after creation
+        attachments,
+        commenters: [],
+        commentsTotal: 0,
+        communities,
+        createdAt,
+        creator,
+        // linkPreview,
+        updatedAt,
+        votesTotal,
+
+        // May need to retain these to avoid breaking legacy code.
+        // TODO: Check if these are still required.
+        creatorId: creator.id
+      }
+    )
+  }
+// id
+// title
+// details
+// type
+// creator {
+//   id
+//   name
+//   avatarUrl
+// }
+// createdAt
+// updatedAt
+// commenters(first: 3) {
+//   id
+//   name
+//   avatarUrl
+// }
+// commentersTotal
+// ${withComments ? `comments(first: 10, order: "desc") {
+//   items {
+//     id
+//     text
+//     creator {
+//       id
+//       name
+//       avatarUrl
+//     }
+//     attachments {
+//       id
+//       url
+//     }
+//     createdAt
+//   }
+//   total
+//   hasMore
+// }` : ''}
+// linkPreview {
+//   id
+//   title
+//   url
+//   imageUrl
+// }
+// votesTotal
+// myVote
+// communities {
+//   id
+//   name
+//   slug
+// }
+// attachments {
+//   id
+//   position
+//   type
+//   url
+// }`
 }, EnsureLoad), {
   // Class Methods
 

--- a/api/models/post/createPost.js
+++ b/api/models/post/createPost.js
@@ -66,7 +66,7 @@ export function afterCreatingPost (post, opts) {
 
 function updateTagsAndCommunities (post, trx) {
   return post.load([
-    'communities', 'details', 'linkPreview', 'name', 'networks', 'tags', 'user'
+    'communities', 'linkPreview', 'networks', 'tags', 'user'
   ], {transacting: trx})
   .then(() => {
     const { tags, communities } = post.relations

--- a/api/models/post/createPost.js
+++ b/api/models/post/createPost.js
@@ -66,7 +66,7 @@ export function afterCreatingPost (post, opts) {
 
 function updateTagsAndCommunities (post, trx) {
   return post.load([
-    'attachments', 'communities', 'linkPreview', 'networks', 'tags', 'user'
+    'communities', 'media', 'networks', 'tags', 'user'
   ], {transacting: trx})
   .then(() => {
     const { tags, communities } = post.relations
@@ -104,5 +104,6 @@ function updateTagsAndCommunities (post, trx) {
     }).query().update({updated_at: new Date()}).transacting(trx)
 
     return Promise.all(bumpCounts.concat([notifySockets, updateCommunityTags]))
+      .catch(err => console.error('updateTagsAndCommunities:', err))
   })
 }

--- a/api/models/post/createPost.js
+++ b/api/models/post/createPost.js
@@ -104,6 +104,5 @@ function updateTagsAndCommunities (post, trx) {
     }).query().update({updated_at: new Date()}).transacting(trx)
 
     return Promise.all(bumpCounts.concat([notifySockets, updateCommunityTags]))
-      .catch(err => console.error('updateTagsAndCommunities:', err))
   })
 }

--- a/api/models/post/createPost.js
+++ b/api/models/post/createPost.js
@@ -66,7 +66,7 @@ export function afterCreatingPost (post, opts) {
 
 function updateTagsAndCommunities (post, trx) {
   return post.load([
-    'communities', 'media', 'networks', 'tags', 'user'
+    'communities', 'linkPreview', 'media', 'networks', 'tags', 'user'
   ], {transacting: trx})
   .then(() => {
     const { tags, communities } = post.relations

--- a/api/models/post/createPost.js
+++ b/api/models/post/createPost.js
@@ -66,7 +66,7 @@ export function afterCreatingPost (post, opts) {
 
 function updateTagsAndCommunities (post, trx) {
   return post.load([
-    'communities', 'linkPreview', 'media', 'networks', 'tags', 'user'
+    'communities', 'details', 'linkPreview', 'name', 'networks', 'tags', 'user'
   ], {transacting: trx})
   .then(() => {
     const { tags, communities } = post.relations
@@ -90,12 +90,11 @@ function updateTagsAndCommunities (post, trx) {
     // room it's being pushed to.
     // TODO: eventually we will need to push to socket rooms for networks.
     const payload = post.getNewPostSocketPayload()
-    const notifySockets = communities.map(c => {
-      const communities = [ c ]
+    const notifySockets = payload.communities.map(c => {
       pushToSockets(
         communityRoom(c.id),
         'newPost',
-        Object.assign({}, payload, { communities })
+        Object.assign({}, payload, { communities: [ c ] })
       )
     })
 

--- a/api/models/post/createPost.test.js
+++ b/api/models/post/createPost.test.js
@@ -15,7 +15,7 @@ describe('afterCreatingPost', () => {
       u1: new User({name: 'U1', email: 'a@b.c', active: true}).save()
     }))
     .then(props => {
-      post = factories.post({user_id: props.u1.id, description: 'wow!'})
+      post = factories.post({user_id: props.u1.id, description: 'wow!', link_preview_id: null})
     })
   )
 

--- a/api/models/util/relations.js
+++ b/api/models/util/relations.js
@@ -1,35 +1,34 @@
 import { camelCase, mapKeys, reduce } from 'lodash/fp'
 
-const valuesToString = (v, k, acc) => {
-  const stringifyKeys = [
-    'id',
-    'createdAt',
-    'updatedAt'
-  ]
-  acc[k] = stringifyKeys.includes(k) ? v.toString() : v
-  return acc
-}
-
 // Pick some fields from a `belongsTo` relation. Takes a relation and an array
 // of field names. Snake case will be rewritten to camelcase in output property
-// names. Some values are converted via toString (dates, ids).
-export const refineOne = (relation, fields) => {
+// names. An optional third parameter specifies fields to rewrite. For example:
+//
+//   refineOne(
+//     post,
+//     [ 'id', 'created_at', 'name' ],
+//     { 'name': 'title' }
+//   )
+//
+// would yield something like:
+//
+//   { createdAt: '...', id: '1', 'title': 'Aardvarks' }
+export const refineOne = (relation, fields, rewrite) => {
   // A relation might simply not be set, so not a programmer error:
   if (!relation) return null
 
   // Lack of field names is a problem though...
   if (!Array.isArray(fields)) throw new Error ('Expected an array of field names.')
 
-  return reduce(
-    valuesToString,
-    mapKeys(k => camelCase(k), relation.pick(fields)),
-    {}
+  return mapKeys(
+    k => rewrite && rewrite[k] ? rewrite[k] : camelCase(k),
+    relation.pick(fields)
   )
 }
 
 // Pick some fields from a `belongsToMany` relation
-export const refineMany = (relation, fields) => {
+export const refineMany = (relation, fields, rewrite) => {
   if (!relation) return []
   if (!Array.isArray(fields)) throw new Error ('Expected an array of field names.')
-  return relation.map(entity => refineOne(entity, fields))
+  return relation.map(entity => refineOne(entity, fields, rewrite))
 }

--- a/api/models/util/relations.js
+++ b/api/models/util/relations.js
@@ -1,0 +1,35 @@
+import { camelCase, mapKeys, reduce } from 'lodash/fp'
+
+const valuesToString = (v, k, acc) => {
+  const stringifyKeys = [
+    'id',
+    'createdAt',
+    'updatedAt'
+  ]
+  acc[k] = stringifyKeys.includes(k) ? v.toString() : v
+  return acc
+}
+
+// Pick some fields from a `belongsTo` relation. Takes a relation and an array
+// of field names. Snake case will be rewritten to camelcase in output property
+// names. Some values are converted via toString (dates, ids).
+export const refineOne = (relation, fields) => {
+  // A relation might simply not be set, so not a programmer error:
+  if (!relation) return null
+
+  // Lack of field names is a problem though...
+  if (!Array.isArray(fields)) throw new Error ('Expected an array of field names.')
+
+  return reduce(
+    valuesToString,
+    mapKeys(k => camelCase(k), relation.pick(fields)),
+    {}
+  )
+}
+
+// Pick some fields from a `belongsToMany` relation
+export const refineMany = (relation, fields) => {
+  if (!relation) return []
+  if (!Array.isArray(fields)) throw new Error ('Expected an array of field names.')
+  return relation.map(entity => refineOne(entity, fields))
+}

--- a/api/models/util/relations.test.js
+++ b/api/models/util/relations.test.js
@@ -2,7 +2,7 @@ import rootPath from 'root-path'
 const factories = require(rootPath('test/setup/factories'))
 import { refineMany, refineOne } from './relations'
 
-describe.only('refineOne', () => {
+describe('refineOne', () => {
   let post
 
   beforeEach(() => {

--- a/api/models/util/relations.test.js
+++ b/api/models/util/relations.test.js
@@ -1,0 +1,47 @@
+import rootPath from 'root-path'
+const factories = require(rootPath('test/setup/factories'))
+import { refineMany, refineOne } from './relations'
+
+describe.only('refineOne', () => {
+  let post
+
+  beforeEach(() => {
+    post = factories.post({
+      floofle: 'flarfle',
+      id: 1,
+      i_am_snake_case: 'sssssssss',
+      morganflorfle: 'worble',
+      slumptifargle: 99
+    })
+  })
+
+  it('returns the specified subset of fields', () => {
+    const expected = { floofle: 'flarfle' }
+    const actual = refineOne(post, [ 'floofle' ])
+    expect(actual).to.deep.equal(expected)
+  })
+
+  it('rewrites field names', () => {
+    const expected = {
+      aardvark: 'flarfle',
+      id: 1,
+      slumptifargle: 99,
+    }
+    const actual = refineOne(
+      post,
+      [ 'floofle', 'id', 'slumptifargle' ],
+      { floofle: 'aardvark' }
+    )
+    expect(actual).to.deep.equal(expected)
+  })
+
+  it('converts snake_case to camelCase', () => {
+    const expected = { iAmSnakeCase: 'sssssssss' }
+    const actual = refineOne(post, [ 'i_am_snake_case' ])
+    expect(actual).to.deep.equal(expected)
+  })
+
+  it('throws if fields is not an array', () => {
+    expect(() => refineOne(post)).to.throw()
+  })
+})

--- a/migrations/20171014111135_link-preview-id-bigint.js
+++ b/migrations/20171014111135_link-preview-id-bigint.js
@@ -1,0 +1,2 @@
+exports.up = knex => knex.raw('ALTER TABLE posts ALTER COLUMN link_preview_id TYPE bigint')
+exports.down = knex => knex.raw('ALTER TABLE posts ALTER COLUMN link_preview_id TYPE integer')


### PR DESCRIPTION
This:
  - [x] returns a slightly modified shape from `updateUserSocketRoom` which removes the guesswork I used when I wrote it the first time around
  - [x] returns a much more detailed post object from `createPost`
  - [x] migrates `link_preview_id` from `integer` to `bigint`
  - [x] adds some helpers to `api/models/util` to simplify some of the boilerplate
