### PR TITLE
quotes looked like &quot; in slack messages

### DIFF
--- a/api/services/Slack.js
+++ b/api/services/Slack.js
@@ -13,7 +13,7 @@ module.exports = {
         Frontend.Route.profile(relatedUser), relatedUser.get('name'),
         Frontend.Route.community(community), community.get('name'))
     } else {
-      return format('<%s|%s> posted <%s|"%s"> in <%s|%s>',
+      return format('<%s|%s> posted <%s|%s> in <%s|%s>',
         Frontend.Route.profile(creator), creator.get('name'),
         Frontend.Route.post(post, community), post.get('name'),
         Frontend.Route.community(community), community.get('name'))


### PR DESCRIPTION
They didn't used to so I'm not sure when it changed.

![screenshot_20171101-104027](https://user-images.githubusercontent.com/1409121/32280106-205b8bf0-bef1-11e7-977e-9a179d8d3cc2.png)
