### PR TITLE
Web 330/network settings mutations

### DIFF
--- a/api/graphql/index.js
+++ b/api/graphql/index.js
@@ -4,6 +4,8 @@ import { join } from 'path'
 import setupBridge from '../../lib/graphql-bookshelf-bridge'
 import { presentQuerySet } from '../../lib/graphql-bookshelf-bridge/util'
 import {
+  addCommunityToNetwork,
+  addNetworkModeratorRole,
   addModerator,
   addSkill,
   createComment,
@@ -23,8 +25,10 @@ import {
   regenerateAccessCode,
   registerDevice,
   reinviteAll,
+  removeCommunityFromNetwork,
   removeMember,
   removeModerator,
+  removeNetworkModeratorRole,
   removePost,
   removeSkill,
   resendInvitation,
@@ -54,7 +58,7 @@ async function createSchema (userId, isAdmin) {
 
   const allResolvers = Object.assign({
     Query: makeQueries(userId, fetchOne, fetchMany),
-    Mutation: makeMutations(userId),
+    Mutation: makeMutations(userId, isAdmin),
 
     FeedItemContent: {
       __resolveType (data, context, info) {
@@ -134,52 +138,108 @@ export function makeQueries (userId, fetchOne, fetchMany) {
   }
 }
 
-export function makeMutations (userId) {
+export function makeMutations (userId, isAdmin) {
   return {
-    updateMe: (root, { changes }) => updateMe(userId, changes),
-    createPost: (root, { data }) => createPost(userId, data),
-    updatePost: (root, args) => updatePost(userId, args),
+    addCommunityToNetwork: (root, { communityId, networkId }) =>
+      addCommunityToNetwork({ userId, isAdmin }, { communityId, networkId }),
+
+    addModerator: (root, { personId, communityId }) =>
+      addModerator(userId, personId, communityId),
+
+    addNetworkModeratorRole: (root, { personId, networkId }) =>
+      addNetworkModeratorRole({ userId, isAdmin }, { personId, networkId }),
+
+    addSkill: (root, { name }) => addSkill(userId, name),
+
     createComment: (root, { data }) => createComment(userId, data),
+
+    createCommunity: (root, { data }) => createCommunity(userId, data),
+
+    createInvitation: (root, {communityId, data}) =>
+      createInvitation(userId, communityId, data),
+
     createMessage: (root, { data }) => {
       data.postId = data.messageThreadId
       return createComment(userId, data)
     },
-    findOrCreateThread: (root, { data }) => findOrCreateThread(userId, data),
-    findOrCreateLinkPreviewByUrl: (root, { data }) => findOrCreateLinkPreviewByUrl(data),
-    leaveCommunity: (root, { id }) => leaveCommunity(userId, id),
-    markActivityRead: (root, { id }) => markActivityRead(userId, id),
-    markAllActivitiesRead: (root) => markAllActivitiesRead(userId),
-    subscribe: (root, { communityId, topicId, isSubscribing }) =>
-      subscribe(userId, topicId, communityId, isSubscribing),
-    updateCommunitySettings: (root, { id, changes }) =>
-      updateCommunity(userId, id, changes),
-    updateCommunityTopic: (root, args) => updateCommunityTopic(userId, args),
-    updateMembership: (root, args) => updateMembership(userId, args),
-    updateNetwork: (root, args) => updateNetwork(userId, args),
-    unlinkAccount: (root, { provider }) => unlinkAccount(userId, provider),
-    vote: (root, { postId, isUpvote }) => vote(userId, postId, isUpvote),
-    addModerator: (root, { personId, communityId }) =>
-      addModerator(userId, personId, communityId),
-    removeModerator: (root, { personId, communityId }) =>
-      removeModerator(userId, personId, communityId),
-    deletePost: (root, { id }) =>
-      deletePost(userId, id),
-    addSkill: (root, { name }) => addSkill(userId, name),
-    removeSkill: (root, { id, name }) => removeSkill(userId, id || name),
-    removeMember: (root, { personId, communityId }) => removeMember(userId, personId, communityId),
-    regenerateAccessCode: (root, { communityId }) => regenerateAccessCode(userId, communityId),
-    createInvitation: (root, {communityId, data}) => createInvitation(userId, communityId, data),
-    expireInvitation: (root, {invitationId}) => expireInvitation(userId, invitationId),
-    resendInvitation: (root, {invitationId}) => resendInvitation(userId, invitationId),
-    reinviteAll: (root, {communityId}) => reinviteAll(userId, communityId),
-    useInvitation: (root, { invitationToken, accessCode }) => useInvitation(userId, invitationToken, accessCode),
-    flagInappropriateContent: (root, { data }) => flagInappropriateContent(userId, data),
-    removePost: (root, { postId, communityId, slug }) => removePost(userId, postId, communityId || slug),
-    createCommunity: (root, { data }) => createCommunity(userId, data),
+
+    createPost: (root, { data }) => createPost(userId, data),
+
     deleteComment: (root, { id }) => deleteComment(userId, id),
+
+    deletePost: (root, { id }) => deletePost(userId, id),
+
+    expireInvitation: (root, {invitationId}) =>
+      expireInvitation(userId, invitationId),
+
+    findOrCreateThread: (root, { data }) => findOrCreateThread(userId, data),
+
+    findOrCreateLinkPreviewByUrl: (root, { data }) =>
+      findOrCreateLinkPreviewByUrl(data),
+
+    flagInappropriateContent: (root, { data }) =>
+      flagInappropriateContent(userId, data),
+
+    leaveCommunity: (root, { id }) => leaveCommunity(userId, id),
+
+    markActivityRead: (root, { id }) => markActivityRead(userId, id),
+
+    markAllActivitiesRead: (root) => markAllActivitiesRead(userId),
+
+    pinPost: (root, { postId, communityId }) =>
+      pinPost(userId, postId, communityId),
+
+    regenerateAccessCode: (root, { communityId }) =>
+      regenerateAccessCode(userId, communityId),
+
     registerDevice: (root, { playerId, platform, version }) =>
       registerDevice(userId, { playerId, platform, version }),
-    pinPost: (root, { postId, communityId }) => pinPost(userId, postId, communityId)
+
+    reinviteAll: (root, {communityId}) => reinviteAll(userId, communityId),
+
+    removeCommunityFromNetwork: (root, { communityId, networkId }) =>
+      removeCommunityFromNetwork({ userId, isAdmin }, { communityId, networkId }),
+
+    removeMember: (root, { personId, communityId }) =>
+      removeMember(userId, personId, communityId),
+
+    removeModerator: (root, { personId, communityId }) =>
+      removeModerator(userId, personId, communityId),
+
+    removeNetworkModeratorRole: (root, { personId, networkId }) =>
+      removeNetworkModeratorRole({ userId, isAdmin }, { personId, networkId }),
+
+    removePost: (root, { postId, communityId, slug }) =>
+      removePost(userId, postId, communityId || slug),
+
+    removeSkill: (root, { id, name }) => removeSkill(userId, id || name),
+
+    resendInvitation: (root, {invitationId}) =>
+      resendInvitation(userId, invitationId),
+
+    subscribe: (root, { communityId, topicId, isSubscribing }) =>
+      subscribe(userId, topicId, communityId, isSubscribing),
+
+    unlinkAccount: (root, { provider }) =>
+      unlinkAccount(userId, provider),
+
+    updateCommunitySettings: (root, { id, changes }) =>
+      updateCommunity(userId, id, changes),
+
+    updateCommunityTopic: (root, args) => updateCommunityTopic(userId, args),
+
+    updateMe: (root, { changes }) => updateMe(userId, changes),
+
+    updateMembership: (root, args) => updateMembership(userId, args),
+
+    updateNetwork: (root, args) => updateNetwork(userId, args),
+
+    updatePost: (root, args) => updatePost(userId, args),
+
+    useInvitation: (root, { invitationToken, accessCode }) =>
+      useInvitation(userId, invitationToken, accessCode),
+
+    vote: (root, { postId, isUpvote }) => vote(userId, postId, isUpvote)
   }
 }
 

--- a/api/graphql/mutations/index.js
+++ b/api/graphql/mutations/index.js
@@ -6,7 +6,13 @@ import underlyingFindLinkPreview from '../../models/linkPreview/findOrCreateByUr
 import convertGraphqlData from './convertGraphqlData'
 
 export { createComment, deleteComment, canDeleteComment } from './comment'
-export { updateNetwork } from './network'
+export {
+  addCommunityToNetwork,
+  addNetworkModeratorRole,
+  removeCommunityFromNetwork,
+  removeNetworkModeratorRole,
+  updateNetwork
+} from './network'
 export { registerDevice } from './mobile'
 export { subscribe } from './topic'
 export {

--- a/api/graphql/mutations/network.js
+++ b/api/graphql/mutations/network.js
@@ -2,6 +2,42 @@ import validateNetworkData from '../../models/network/validateNetworkData'
 import underlyingUpdateNetwork from '../../models/network/updateNetwork'
 import convertGraphqlData from './convertGraphqlData'
 
+export function addCommunityToNetwork (userId, { communityId, networkId }) {
+  return NetworkMembership.hasModeratorRole(userId, networkId)
+    .then(ok => {
+      if (!ok) throw new Error("You don't have permission to modify this network.")
+    })
+    .then(() => true)
+}
+
+export function addNetworkModeratorRole (userId, { personId, networkId }) {
+  return NetworkMembership.hasModeratorRole(userId, networkId)
+    .then(ok => {
+      if (!ok) throw new Error("You don't have permission to modify this network.")
+    })
+    .then(() => NetworkMembership.addModerator(personId, networkId))
+    .then(() => Network.find(networkId))
+}
+
+export function removeCommunityFromNetwork (userId, { communityId, networkId }) {
+  return NetworkMembership.hasModeratorRole(userId, networkId)
+    .then(ok => {
+      if (!ok) throw new Error("You don't have permission to modify this network.")
+    })
+    .then(() => true)
+}
+
+export function removeNetworkModeratorRole (userId, { personId, networkId }) {
+  return NetworkMembership.hasModeratorRole(userId, networkId)
+    .then(ok => {
+      if (!ok) throw new Error("You don't have permission to modify this network.")
+    })
+    .then(() => NetworkMembership
+      .where({ user_id: userId, network_id: networkId })
+      .delete())
+    .then(() => Network.find(networkId))
+}
+
 export function updateNetwork (userId, { id, data }) {
   const convertedData = convertGraphqlData(data)
   return NetworkMembership.hasModeratorRole(userId, id)

--- a/api/graphql/mutations/network.test.js
+++ b/api/graphql/mutations/network.test.js
@@ -1,6 +1,6 @@
 import * as mutations from './network'
 
-describe.only('network mutations', () => {
+describe('network mutations', () => {
   let community, network, user
 
   before(() => {

--- a/api/graphql/mutations/network.test.js
+++ b/api/graphql/mutations/network.test.js
@@ -1,0 +1,113 @@
+import * as mutations from './network'
+
+describe.only('network mutations', () => {
+  let community, network, user
+
+  before(() => {
+    network = new Network({ name: 'Bargle' })
+    user = new User({ email: 'flargle@bargle' })
+    return Promise.all([ network.save(), user.save() ])
+  })
+
+  after(() => {
+    return Promise.all([ network.destroy(), user.destroy() ])
+  })
+
+  describe('networkMutationPermissionCheck', () => {
+    after(() => {
+      return NetworkMembership.where('user_id', user.id).destroy()
+    })
+
+    it('does not throw when user is admin', () => {
+      return expect(mutations.networkMutationPermissionCheck({
+        isAdmin: true
+      })).not.to.be.rejected
+    })
+
+    it('does not throw when user is network moderator', async () => {
+      await NetworkMembership.addModerator(user.id, network.id)
+      return expect(mutations.networkMutationPermissionCheck({
+        userId: user.id,
+        isAdmin: false
+      }, network.id)).not.to.be.rejected
+    })
+
+    it('throws when user is not admin or network moderator', () => {
+      return expect(mutations.networkMutationPermissionCheck({
+        userId: user.id,
+        isAdmin: false
+      }, 99)).to.be.rejected
+    })
+  })
+
+  describe('communities', () => {
+    beforeEach(async () => {
+      community = await new Community({ name: 'Wargle', slug: 'wargle' }).save()
+    })
+
+    afterEach(() => {
+      return community.destroy()
+    })
+
+    describe('addCommunityToNetwork', () => {
+      it('sets the correct network_id', async () => {
+        await mutations.addCommunityToNetwork(
+          { userId: user.id, isAdmin: true },
+          { communityId: community.id, networkId: network.id }
+        )
+        await community.fetch({ withRelated: [ 'network' ] })
+        expect(community.relations.network.id).to.equal(network.id)
+      })
+    })
+
+    describe('removeCommunityFromNetwork', () => {
+      it('removes the network relation', async () => {
+        await community
+          .save('network_id', network.id, { method: 'update', patch: true })
+        await mutations.removeCommunityFromNetwork(
+          { userId: user.id, isAdmin: true },
+          { communityId: community.id, networkId: network.id }
+        )
+        await community.fetch({ withRelated: [ 'network' ] })
+        expect(community.relations.network).to.equal(undefined)
+      })
+    })
+  })
+
+  describe('moderators', () => {
+    afterEach(() => {
+      return NetworkMembership.where('user_id', user.id).destroy()
+    })
+
+    describe('addNetworkModeratorRole', () => {
+      it('throws if already a moderator', async () => {
+        await NetworkMembership.addModerator(user.id, network.id)
+        return expect(mutations.addNetworkModeratorRole(
+          { userId: user.id },
+          { personId: user.id, networkId: network.id }
+        )).to.be.rejectedWith(/already has moderator/)
+      })
+
+      it('adds a moderator', async () => {
+        await mutations.addNetworkModeratorRole(
+          { isAdmin: true },
+          { personId: user.id, networkId: network.id }
+        )
+        await network.fetch({ withRelated: [ 'moderators' ] })
+        expect(network.relations.moderators.first().id).to.equal(user.id)
+      })
+    })
+
+    describe('removeNetworkModeratorRole', () => {
+      it('removes a moderator', async () => {
+        await NetworkMembership.addModerator(user.id, network.id)
+        await mutations.removeNetworkModeratorRole(
+          { isAdmin: true },
+          { personId: user.id, networkId: network.id }
+        )
+        await network.fetch({ withRelated: [ 'moderators' ] })
+        expect(network.relations.moderators.length).to.equal(0)
+      })
+    })
+  })
+})

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -517,7 +517,9 @@ input UserSettingsInput {
 }
 
 type Mutation {
+  addCommunityToNetwork(communityId: ID, networkId: ID): Network
   addModerator(personId: ID, communityId: ID): Community
+  addNetworkModerator(personId: ID, networkId: ID): Network
   addSkill(name: String): Skill
   createComment(data: CommentInput): Comment
   createCommunity(data: CommunityInput): Membership
@@ -533,11 +535,14 @@ type Mutation {
   leaveCommunity(id: ID): ID
   markActivityRead(id: ID): Activity
   markAllActivitiesRead: GenericResult
+  pinPost(postId: ID, communityId: ID): GenericResult
   regenerateAccessCode(communityId: ID): Community
   registerDevice(playerId: String, platform: String, version: String): GenericResult
-  reinviteAll(communityId: ID): GenericResult,
+  reinviteAll(communityId: ID): GenericResult
+  removeCommunityFromNetwork(communityId: ID, networkId: ID): Network
   removeMember(personId: ID, communityId: ID): Community
   removeModerator(personId: ID, communityId: ID): Community
+  removeNetworkModerator(personId: ID, networkId: ID): Network
   removePost(postId: ID, slug: String, communityId: ID): GenericResult
   removeSkill(id: ID, name: String): GenericResult
   resendInvitation(invitationId: ID): GenericResult
@@ -551,7 +556,6 @@ type Mutation {
   updatePost(id: ID, data: PostInput): Post
   useInvitation(userId: ID, invitationToken: String, accessCode: String): InvitationUseResult,
   vote(postId: ID, isUpvote: Boolean): Post
-  pinPost(postId: ID, communityId: ID): GenericResult
 }
 
 type InvitationUseResult {

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -519,7 +519,7 @@ input UserSettingsInput {
 type Mutation {
   addCommunityToNetwork(communityId: ID, networkId: ID): Network
   addModerator(personId: ID, communityId: ID): Community
-  addNetworkModerator(personId: ID, networkId: ID): Network
+  addNetworkModeratorRole(personId: ID, networkId: ID): Network
   addSkill(name: String): Skill
   createComment(data: CommentInput): Comment
   createCommunity(data: CommunityInput): Membership
@@ -542,7 +542,7 @@ type Mutation {
   removeCommunityFromNetwork(communityId: ID, networkId: ID): Network
   removeMember(personId: ID, communityId: ID): Community
   removeModerator(personId: ID, communityId: ID): Community
-  removeNetworkModerator(personId: ID, networkId: ID): Network
+  removeNetworkModeratorRole(personId: ID, networkId: ID): Network
   removePost(postId: ID, slug: String, communityId: ID): GenericResult
   removeSkill(id: ID, name: String): GenericResult
   resendInvitation(invitationId: ID): GenericResult


### PR DESCRIPTION
This:
 - [x] adds mutations for single add/remove of moderators and communities
 - [x] makes `isAdmin` available in `makeMutations`
 - [x] reformats `makeMutations` so I can read it (lemme know if you hate all that whitespace!)