### PR TITLE
Seeder

### DIFF
--- a/api/graphql/index.js
+++ b/api/graphql/index.js
@@ -78,7 +78,7 @@ async function createSchema (userId, isAdmin) {
 
   return makeExecutableSchema({
     typeDefs: [schemaText],
-    resolvers: requireUser(allResolvers, userId)
+    resolvers: requireUser(allResolvers, userId, isAdmin)
   })
 }
 
@@ -271,8 +271,8 @@ export const createRequestHandler = () =>
     }
   })
 
-function requireUser (resolvers, userId) {
-  if (userId) return resolvers
+function requireUser (resolvers, userId, isAdmin) {
+  if (userId || isAdmin) return resolvers
 
   const error = () => {
     throw new Error('not logged in')

--- a/api/graphql/index.js
+++ b/api/graphql/index.js
@@ -5,6 +5,7 @@ import setupBridge from '../../lib/graphql-bookshelf-bridge'
 import { presentQuerySet } from '../../lib/graphql-bookshelf-bridge/util'
 import {
   addCommunityToNetwork,
+  addMember,
   addNetworkModeratorRole,
   addModerator,
   addSkill,
@@ -143,6 +144,9 @@ export function makeMutations (userId, isAdmin) {
   return {
     addCommunityToNetwork: (root, { communityId, networkId }) =>
       addCommunityToNetwork({ userId, isAdmin }, { communityId, networkId }),
+
+    addMemberToCommunity: (root, { personId, communityId }) =>
+      addMember({ userId, isAdmin }, personId, communityId),
 
     addModerator: (root, { personId, communityId }) =>
       addModerator(userId, personId, communityId),

--- a/api/graphql/mutations/community.js
+++ b/api/graphql/mutations/community.js
@@ -37,6 +37,13 @@ export function removeModerator (userId, personId, communityId) {
   })
 }
 
+// Admin-only (for now) addition of member
+export async function addMember (authZ, personId, communityId) {
+  if (!authZ.isAdmin) throw new Error("You don't have permission to modify this community")
+  await Membership.create(personId, communityId)
+  return Membership.find(personId, communityId)
+}
+
 /**
  * As a moderator, removes member from a community.
  */

--- a/api/graphql/mutations/index.js
+++ b/api/graphql/mutations/index.js
@@ -24,6 +24,7 @@ export {
 } from './invitation'
 export {
   updateCommunity,
+  addMember,
   addModerator,
   removeModerator,
   removeMember,

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -527,6 +527,7 @@ input UserSettingsInput {
 
 type Mutation {
   addCommunityToNetwork(communityId: ID, networkId: ID): Network
+  addMemberToCommunity(personId: ID, communityId: ID): Membership
   addModerator(personId: ID, communityId: ID): Community
   addNetworkModeratorRole(personId: ID, networkId: ID): Network
   addSkill(name: String): Skill

--- a/seeds/communities.js
+++ b/seeds/communities.js
@@ -5,6 +5,5 @@ exports.seed = function (knex, Promise) {
     .then(() => knex('communities_users').del())
     .then(() => knex('communities').del())   // Deletes ALL existing entries
     .then(() => knex('communities')
-                    .insert({id: 1, name: 'starter-posts', slug: 'starter-posts'})
-  )
+      .insert({name: 'starter-posts', slug: 'starter-posts'}))
 }


### PR DESCRIPTION
Add a single admin-only mutation, `addMemberToCommunity`. Also removes the `id: 1` from the `starter-posts` seed so that subsequent community creations don't fail (the autoincrement doesn't update if you specify an id).

It also allows an admin login access to any resolver without insisting that they also be logged in as a regular user. I don't think this is vulnerable to abuse, it just opens the way for other admin tools as and when required. Obviously, only @hylo.com addresses will qualify here.