### PR TITLE
Fix versioncheck

### DIFF
--- a/api/controllers/MobileAppController.js
+++ b/api/controllers/MobileAppController.js
@@ -17,7 +17,6 @@ module.exports = {
     const androidVersion = req.param('android-version')
     const version = iosVersion || androidVersion
     const platform = iosVersion ? IOS : ANDROID
-    console.log('shouldUpdate?', shouldUpdate(version, platform))
     return res.ok(shouldUpdate(version, platform))
   },
 

--- a/api/controllers/MobileAppController.js
+++ b/api/controllers/MobileAppController.js
@@ -17,6 +17,7 @@ module.exports = {
     const androidVersion = req.param('android-version')
     const version = iosVersion || androidVersion
     const platform = iosVersion ? IOS : ANDROID
+    console.log('shouldUpdate?', shouldUpdate(version, platform))
     return res.ok(shouldUpdate(version, platform))
   },
 
@@ -60,7 +61,7 @@ function shouldUpdate (version, platform) {
     if (semver.lt(version, process.env.MINIMUM_SUPPORTED_MOBILE_VERSION || '0.0.0')) {
       return resultBuilder(FORCE, platform)
     } else {
-      return undefined
+      return { success: true }
     }
   }
 

--- a/test/unit/controllers/MobileAppController.test.js
+++ b/test/unit/controllers/MobileAppController.test.js
@@ -112,7 +112,7 @@ describe('MobileAppController', () => {
     it('returns success for ios version > 2.0', () => {
       req.params = {'ios-version': '2.0.1'}
       MobileAppController.checkShouldUpdate(req, res)
-      expect(res.body).to.equal(true)
+      expect(res.body.success).to.equal(true)
     })
   })
 })

--- a/test/unit/controllers/MobileAppController.test.js
+++ b/test/unit/controllers/MobileAppController.test.js
@@ -91,28 +91,28 @@ describe('MobileAppController', () => {
       expect(res.body).to.deep.equal(expected)
     })
 
-    it('returns undefined for android version 2.0', () => {
+    it('returns success for android version 2.0', () => {
       req.params = {'android-version': '2.0'}
       MobileAppController.checkShouldUpdate(req, res)
-      expect(res.body).to.equal(undefined)
+      expect(res.body.success).to.equal(true)
     })
 
-    it('returns undefined for ios version 2.0', () => {
+    it('returns success for ios version 2.0', () => {
       req.params = {'ios-version': '2.0'}
       MobileAppController.checkShouldUpdate(req, res)
-      expect(res.body).to.equal(undefined)
+      expect(res.body.success).to.equal(true)
     })
 
-    it('returns undefined for android version > 2.0', () => {
+    it('returns success for android version > 2.0', () => {
       req.params = {'android-version': '2.0.1'}
       MobileAppController.checkShouldUpdate(req, res)
-      expect(res.body).to.equal(undefined)
+      expect(res.body.success).to.equal(true)
     })
 
-    it('returns undefined for ios version > 2.0', () => {
+    it('returns success for ios version > 2.0', () => {
       req.params = {'ios-version': '2.0.1'}
       MobileAppController.checkShouldUpdate(req, res)
-      expect(res.body).to.equal(undefined)
+      expect(res.body).to.equal(true)
     })
   })
 })


### PR DESCRIPTION
This is a pretty trivial one. Currently the request will return `undefined` for the most part (if a user has the correct version). Even though the status code is correct, the fact that we're returning an empty body for an `application/json` request is technically an error because empty string is not, as it turns out, valid JSON :laughing: so there has been a swallowed error on startup for a long time.

Once I started logging it it took me quite a while to realise that it wasn't the source of our problems with the dev environment, but we should still fix it. Swallowed errors ain't cool.

Note: the client code ignores the body unless it has an error property, so this doesn't break anything.