### PR TITLE
408 post title truncates

### DIFF
--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -18,6 +18,7 @@ import {
   filterAndSortUsers
 } from '../services/Search/util'
 import { isFollowing } from '../models/group/queryUtils'
+import he from 'he';
 
 // this defines what subset of attributes and relations in each Bookshelf model
 // should be exposed through GraphQL, and what query filters should be applied
@@ -138,7 +139,7 @@ export default async function makeModels (userId, isAdmin) {
         'is_public'
       ],
       getters: {
-        title: p => p.get('name'),
+        title: p => he.decode(p.get('name')),
         details: p => p.get('description'),
         detailsText: p => p.getDetailsText(),
         isPublic: p => p.get('is_public'),

--- a/api/models/post/setupPostAttrs.js
+++ b/api/models/post/setupPostAttrs.js
@@ -1,10 +1,11 @@
 import { merge, pick } from 'lodash'
 import { getOr } from 'lodash/fp'
 import { sanitize } from 'hylo-utils/text'
+import he from 'he';
 
 export default function setupPostAttrs (userId, params) {
   const attrs = merge({
-    name: sanitize(params.name),
+    name: sanitize(he.encode(params.name)),
     description: sanitize(params.description),
     user_id: userId,
     visibility: params.public ? Post.Visibility.PUBLIC_READABLE : Post.Visibility.DEFAULT,

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "hast-util-select": "^1.0.1",
     "hast-util-to-string": "^1.0.1",
     "hastscript": "^3.1.0",
+    "he": "^1.2.0",
     "hylo-utils": "Hylozoic/hylo-utils#c4db0b4",
     "image-size": "^0.3.5",
     "jade": "^1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3936,6 +3936,11 @@ he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"


### PR DESCRIPTION
Addresses https://github.com/Hylozoic/hylo-evo/issues/408

Add [he](https://www.npmjs.com/package/he) for HTML entity encoding/decoding

In the example from the issue, `Communities <=> Food <=> The Land <=> Tech` is saved in the database as `Communities &#x3C;=&#x3E; Food &#x3C;=&#x3E; The Land &#x3C;=&#x3E; Tech` 