### PR TITLE
Add post.created_at sort option to posts search

### DIFF
--- a/api/services/Search/util.js
+++ b/api/services/Search/util.js
@@ -5,7 +5,8 @@ export const filterAndSortPosts = curry((opts, q) => {
   const { search, sortBy = 'updated', topic, showPinnedFirst, type, boundingBox } = opts
   const sortColumns = {
     votes: 'num_votes',
-    updated: 'posts.updated_at'
+    updated: 'posts.updated_at',
+    created: 'posts.created_at'
   }
 
   const sort = sortColumns[sortBy] || values(sortColumns).find(v => v === sortBy)


### PR DESCRIPTION
Required by https://github.com/Hylozoic/hylo-evo/pull/684