### PR TITLE
Fix db seeding

### DIFF
--- a/seeds/migrations.js
+++ b/seeds/migrations.js
@@ -1,17 +1,18 @@
 const fs = require('fs')
 const path = require('path')
+const Promise = require('bluebird')
 
-exports.seed = function (knex, Promise) {
+exports.seed = function (knex) {
   return knex('knex_migrations').del()
     .then(() => {
       const files = fs.readdirSync(path.join(__dirname, '..', 'migrations'))
-      return addMigrations(knex, Promise, files.filter(f => f.slice(-3) === '.js'))
+      return addMigrations(knex, files.filter(f => f.slice(-3) === '.js'))
     })
 }
 
 // Add all migrations in directory to knex_migrations (any .js file in the
 // directory is assumed to be a migration).
-function addMigrations (knex, Promise, migrations) {
+function addMigrations (knex, migrations) {
   return Promise.reduce(
     migrations,
     (_, name) => knex('knex_migrations').insert({


### PR DESCRIPTION
Hello there :wave: 
while, trying to run the project locally encountered the following error:

```
(base) ➜  hylo-node git:(dev) ./node_modules/.bin/knex seed:run
Using environment: development
Error: Error while executing "/home/vesko/Workspace/hylo-node/seeds/migrations.js" seed: Cannot read property 'reduce' of undefined
    at Seeder._waterfallBatch (/home/vesko/Workspace/hylo-node/node_modules/knex/lib/seed/Seeder.js:146:23)
TypeError: Cannot read property 'reduce' of undefined
    at addMigrations (/home/vesko/Workspace/hylo-node/seeds/migrations.js:15:18)
    at /home/vesko/Workspace/hylo-node/seeds/migrations.js:8:14
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Seeder._waterfallBatch (/home/vesko/Workspace/hylo-node/node_modules/knex/lib/seed/Seeder.js:143:9)
```

This stems from the change in the knex after version 0.18+ - bluebird is no longer used by knex and for seeds and
mgirations the promise is no longer passed. More info at https://github.com/knex/knex/blob/master/UPGRADING.md#upgrading-to-version-0180

After the proposed change in this PR the result is:

```
(base) ➜  hylo-node-cl git:(fix-db-seeding) ./node_modules/.bin/knex seed:run
Using environment: development
Ran 3 seed files
```

Is this alright? There were more than 3 migrations in the `migrations` folder in the project.

---

### Some more info from the setup journey

:warning: The results of executing `cat migrations/schema.sql | psql hylo` are in this gist - https://gist.github.com/veselinn/aa5ceb63576736d77c68b100378f24b7 . There are some errors though, not sure how relevant they are :thinking: (Looks like I have problems with the postgies extension at least :thought_balloon: )

---

Please, let me know if I'm missing something, thank you :bow: 
Have an awesome day :sunny:
