### PR TITLE
Docker env seeding

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -29,13 +29,16 @@ Note that this requires a minimum of Docker Compose v1.27 in order to run.
 
 # Initializing the database
 
-```
-export PGPASSWORD=postgres
-createdb hylo -U postgres -h db
-createdb hylo_test -U postgres -h db
-cat migrations/schema.sql | psql -U postgres -h db hylo
-./node_modules/.bin/knex seed:run
-```
+*(All commands given relative to the `.devcontainer` folder.)*
+
+1. Postgres will already be running if you are using the VSCode container integration. If you manage the containers yourself, ensure they are online:  
+   `docker-compose -f docker-compose.servicesonly.yml up`
+2. Run the seed script against the DB container:
+    1. Change your `.env` file to set `DATABASE_URL=postgres://postgres:postgres@db:5432/hylo` so that the seed container can resolve to the correct host.
+    2. Run `docker-compose -f docker-compose.seed.yml up`. The script should terminate with a 0 exit code.
+    3. Restore your `DATABASE_URL` to the appropriate URI to be resolved by the Hylo node backend in your setup. (If running the node service locally or in VSCode, this should be `localhost`.)
+
+> (\*In a VSCode configuration you may be able to run the `init-db.sh` command directly within the VSCode terminal, but YMMV.)
 
 
 # Configuring .env

--- a/.devcontainer/db-seed/Dockerfile
+++ b/.devcontainer/db-seed/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:buster
+
+RUN apt-get update && apt-get install -y postgresql-client
+COPY ./init-db.sh /root/init-db.sh
+
+WORKDIR /root
+CMD ./init-db.sh

--- a/.devcontainer/db-seed/init-db.sh
+++ b/.devcontainer/db-seed/init-db.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+export PGPASSWORD=postgres
+createdb hylo -U postgres -h db
+createdb hylo_test -U postgres -h db
+
+cd /seed
+cat migrations/schema.sql | psql -U postgres -h db hylo
+./node_modules/.bin/knex seed:run

--- a/.devcontainer/docker-compose.seed.yml
+++ b/.devcontainer/docker-compose.seed.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  seed:
+    build:
+      context: ./db-seed
+    volumes:
+      - ../:/seed


### PR DESCRIPTION
Update to #578 that allows DB initialisation commands to be executed by developers opting not to install Postgres tooling locally. May also avoid some potential issues with the existing setup script- unsure if `db` and `localhost` both resolve to the correct server in the VSCode dev env; but this addition makes such a concern explicit.