### PR TITLE
Correctly return message thread id for a pair and current user

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -453,7 +453,7 @@ module.exports = bookshelf.Model.extend(merge({
   },
 
   getMessageThreadWith (userId) {
-    return findThread(this.id, [userId])
+    return findThread([this.id, userId])
   },
 
   unseenThreadCount () {


### PR DESCRIPTION
Fixes: https://github.com/Hylozoic/hylo-evo/issues/748 and https://github.com/Hylozoic/hylo-node/issues/585