### PR TITLE
Slight tweaks to how custom group moderator and type descriptors work

### DIFF
--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -11,6 +11,7 @@ import {
   voteFilter
 } from './filters'
 import { camelCase, mapKeys, startCase } from 'lodash/fp'
+import pluralize from 'pluralize'
 import InvitationService from '../services/InvitationService'
 import {
   filterAndSortPosts,
@@ -330,7 +331,7 @@ export default async function makeModels (userId, isAdmin) {
         settings: g => mapKeys(camelCase, g.get('settings')),
         // XXX: Flag for translation
         typeDescriptor: g => g.get('type_descriptor') || (g.get('type') ? startCase(g.get('type')) : 'Group'),
-        typeDescriptorPlural: g => g.get('type_descriptor_plural') || (g.get('type') ? startCase(g.get('type')) + 's' : 'Groups')
+        typeDescriptorPlural: g => g.get('type_descriptor_plural') || (g.get('type') ? pluralize(startCase(g.get('type'))) : 'Groups')
       },
       filter: nonAdminFilter(groupFilter(userId)),
       fetchMany: ({ autocomplete, boundingBox, context, farmQuery, filter, first, groupIds, groupType, nearCoord, offset, onlyMine, order, parentSlugs, search, sortBy, visibility }) =>

--- a/migrations/20220505135403_remove-default-descriptors-from-groups.js
+++ b/migrations/20220505135403_remove-default-descriptors-from-groups.js
@@ -1,0 +1,19 @@
+
+exports.up = async function (knex) {
+  await knex.schema.alterTable('groups', table => {
+    table.string('type_descriptor').defaultTo(null).alter()
+    table.string('type_descriptor_plural').defaultTo(null).alter()
+    table.string('moderator_descriptor').defaultTo(null).alter()
+    table.string('moderator_descriptor_plural').defaultTo(null).alter()
+  })
+
+  return knex('groups').update({
+    type_descriptor: null,
+    type_descriptor_plural: null,
+    moderator_descriptor: null,
+    moderator_descriptor_plural: null
+  })
+}
+
+exports.down = function (knex) {
+}

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
     "update-migrations": "node ./migrations/scripts/updateMigrationsTable"
   },
   "devDependencies": {
+    "@faker-js/faker": "^6.3.1",
     "babel-plugin-istanbul": "^2.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-datetime": "^1.7.0",
     "chai-spies": "^1.0.0",
     "chai-things": "^0.2.0",
-    "@faker-js/faker": "^6.3.1",
     "foreman": "^3.0.1",
     "i18n": "^0.8.3",
     "mocha": "^9.0.0",
@@ -128,6 +128,7 @@
     "passport-linkedin-token-oauth2": "^0.1.3",
     "performance-now": "^2.1.0",
     "pg": "^8.4.1",
+    "pluralize": "^8.0.0",
     "pretty-data": "^0.40.0",
     "promirepl": "^1.0.1",
     "randomstring": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9811,6 +9811,11 @@ pluralize@1.2.1:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
   integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"


### PR DESCRIPTION
Default is now null and when null we use default text that is easier to translate, instead of storing default "Moderator" or "Group" in the database
Also for type descriptor if that is null then check if type is set and use that if it is, otherwise use Group.