### PR TITLE
Use GraphQLYogaError for errors we want to send along to the front-end

### DIFF
--- a/api/controllers/PostController.js
+++ b/api/controllers/PostController.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { includes } from 'lodash'
 import createPost from '../models/post/createPost'
 import { joinRoom, leaveRoom } from '../services/Websockets'
@@ -14,7 +15,7 @@ const PostController = {
 
     const type = req.param('type')
     if (!includes(Object.keys(namePrefixes), type)) {
-      return res.serverError(new Error(`invalid type: ${type}`))
+      return res.serverError(new GraphQLYogaError(`invalid type: ${type}`))
     }
 
     const attributes = {

--- a/api/graphql/index.js
+++ b/api/graphql/index.js
@@ -1,5 +1,5 @@
 import { envelop, useLazyLoadedSchema } from '@envelop/core'
-const { createServer } = require('@graphql-yoga/node')
+const { createServer, GraphQLYogaError } = require('@graphql-yoga/node')
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import setupBridge from '../../lib/graphql-bookshelf-bridge'
@@ -153,7 +153,7 @@ function createSchema (expressContext) {
           if (data instanceof bookshelf.Model) {
             return info.schema.getType('Post')
           }
-          throw new Error('Post is the only implemented FeedItemContent type')
+          throw new GraphQLYogaError('Post is the only implemented FeedItemContent type')
         }
       },
 
@@ -210,7 +210,7 @@ export function makeAuthenticatedQueries (userId, fetchOne, fetchMany) {
           return {exists: false}
         })
       }
-      throw new Error('Slug is invalid')
+      throw new GraphQLYogaError('Slug is invalid')
     },
     groupExtension: (root, args) => fetchOne('GroupExtension', args),
     groupExtensions: (root, args) => fetchMany('GroupExtension', args),

--- a/api/graphql/mutations/affiliation.js
+++ b/api/graphql/mutations/affiliation.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import validator from 'validator'
 
 export async function canDeleteAffiliation (userId, affiliationId) {
@@ -13,7 +14,7 @@ export function formatUrl (url = '') {
 }
 
 export async function createAffiliation (userId, { role, preposition, orgName, url = '' }) {
-  if (url.length > 0 && !validator.isURL(formatUrl(url))) throw new Error(`Please enter a valid URL.`)
+  if (url.length > 0 && !validator.isURL(formatUrl(url))) throw new GraphQLYogaError(`Please enter a valid URL.`)
   if (userId && role && preposition && orgName) {
     return Affiliation.create({
       userId,
@@ -23,7 +24,7 @@ export async function createAffiliation (userId, { role, preposition, orgName, u
       url: url.length > 0 ? formatUrl(url) : url
     })
   } else {
-    throw new Error(`Invalid parameters to create affiliation`)
+    throw new GraphQLYogaError(`Invalid parameters to create affiliation`)
   }
 }
 
@@ -31,6 +32,6 @@ export function deleteAffiliation (userId, id) {
   if (userId && id && canDeleteAffiliation(userId, id)) {
     return Affiliation.delete(id)
   } else {
-    throw new Error(`Invalid parameters to delete affiliation`)
+    throw new GraphQLYogaError(`Invalid parameters to delete affiliation`)
   }
 }

--- a/api/graphql/mutations/event.js
+++ b/api/graphql/mutations/event.js
@@ -1,14 +1,16 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 import { values, includes } from 'lodash/fp'
 
 export async function respondToEvent(userId, eventId, response) {
 
   if (!includes(response, values(EventInvitation.RESPONSE))) {
-    throw new Error(`response must be one of ${values(EventInvitation.RESPONSE)}. received ${response}`)
+    throw new GraphQLYogaError(`response must be one of ${values(EventInvitation.RESPONSE)}. received ${response}`)
   }
 
   const event = await Post.find(eventId)
   if(!event) {
-    throw new Error('Event not found')
+    throw new GraphQLYogaError('Event not found')
   }
 
   var eventInvitation = await EventInvitation.find({userId, eventId})

--- a/api/graphql/mutations/index.js
+++ b/api/graphql/mutations/index.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { isEmpty, mapKeys, pick, snakeCase, size, trim } from 'lodash'
 import underlyingFindOrCreateThread, {
   validateThreadData
@@ -155,7 +156,7 @@ export function markAllActivitiesRead (userId) {
 export function unlinkAccount (userId, provider) {
   return User.find(userId)
   .then(user => {
-    if (!user) throw new Error(`Couldn't find user with id ${userId}`)
+    if (!user) throw new GraphQLYogaError(`Couldn't find user with id ${userId}`)
     return user.unlinkAccount(provider)
   })
   .then(() => ({success: true}))
@@ -164,9 +165,9 @@ export function unlinkAccount (userId, provider) {
 async function createSkill(name) {
   name = trim(name)
   if (isEmpty(name)) {
-    throw new Error('Skill cannot be blank')
+    throw new GraphQLYogaError('Skill cannot be blank')
   } else if (size(name) > 39) {
-    throw new Error('Skill must be less than 40 characters')
+    throw new GraphQLYogaError('Skill must be less than 40 characters')
   }
   let skill
   try {
@@ -210,9 +211,9 @@ export async function addSkillToLearn (userId, name) {
 
 export async function addSuggestedSkillToGroup (userId, groupId, name) {
   const group = await Group.find(groupId)
-  if (!group) throw new Error(`Invalid group`)
+  if (!group) throw new GraphQLYogaError(`Invalid group`)
   const isModerator = GroupMembership.hasModeratorRole(userId, group)
-  if (!isModerator) throw new Error(`You don't have permission`)
+  if (!isModerator) throw new GraphQLYogaError(`You don't have permission`)
 
   const skill = await createSkill(name)
 
@@ -230,7 +231,7 @@ export async function addSuggestedSkillToGroup (userId, groupId, name) {
 export function removeSkill (userId, skillIdOrName) {
   return Skill.find(skillIdOrName)
   .then(skill => {
-    if (!skill) throw new Error(`Couldn't find skill with ID or name ${skillIdOrName}`)
+    if (!skill) throw new GraphQLYogaError(`Couldn't find skill with ID or name ${skillIdOrName}`)
     return skill.users().detach({ user_id: userId, type: Skill.Type.HAS })
   })
   .then(() => ({success: true}))
@@ -239,7 +240,7 @@ export function removeSkill (userId, skillIdOrName) {
 export function removeSkillToLearn (userId, skillIdOrName) {
   return Skill.find(skillIdOrName)
   .then(skill => {
-    if (!skill) throw new Error(`Couldn't find skill with ID or name ${skillIdOrName}`)
+    if (!skill) throw new GraphQLYogaError(`Couldn't find skill with ID or name ${skillIdOrName}`)
     return skill.usersLearning().detach({ user_id: userId, type: Skill.Type.LEARNING })
   })
   .then(() => ({success: true}))
@@ -247,13 +248,13 @@ export function removeSkillToLearn (userId, skillIdOrName) {
 
 export async function removeSuggestedSkillFromGroup (userId, groupId, skillIdOrName) {
   const group = await Group.find(groupId)
-  if (!group) throw new Error(`Invalid group`)
+  if (!group) throw new GraphQLYogaError(`Invalid group`)
   const isModerator = GroupMembership.hasModeratorRole(userId, group)
-  if (!isModerator) throw new Error(`You don't have permission`)
+  if (!isModerator) throw new GraphQLYogaError(`You don't have permission`)
 
   return Skill.find(skillIdOrName)
     .then(skill => {
-      if (!skill) throw new Error(`Couldn't find skill with ID or name ${skillIdOrName}`)
+      if (!skill) throw new GraphQLYogaError(`Couldn't find skill with ID or name ${skillIdOrName}`)
       return group.suggestedSkills().detach({ skill_id: skill.id })
     })
     .then(() => ({success: true}))
@@ -298,8 +299,8 @@ export async function removePost (userId, postId, groupIdOrSlug) {
     Post.find(postId),
     GroupMembership.hasModeratorRole(userId, group),
     (post, isModerator) => {
-      if (!post) throw new Error(`Couldn't find post with id ${postId}`)
-      if (!isModerator) throw new Error(`You don't have permission to remove this post`)
+      if (!post) throw new GraphQLYogaError(`Couldn't find post with id ${postId}`)
+      if (!isModerator) throw new GraphQLYogaError(`You don't have permission to remove this post`)
       return post.removeFromGroup(groupIdOrSlug)
     })
   .then(() => ({success: true}))

--- a/api/graphql/mutations/invitation.js
+++ b/api/graphql/mutations/invitation.js
@@ -1,14 +1,15 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import InvitationService from '../../services/InvitationService'
 
 export async function createInvitation (userId, groupId, data) {
   const group = await Group.find(groupId)
   return GroupMembership.hasModeratorRole(userId, group)
   .then(ok => {
-    if (!ok) throw new Error("You don't have permission to create an invitation for this group")
+    if (!ok) throw new GraphQLYogaError("You don't have permission to create an invitation for this group")
   })
   .then(() => Group.find(groupId))
   .then((group) => {
-    if (!group) throw new Error('Cannot find group to send invites for')
+    if (!group) throw new GraphQLYogaError('Cannot find group to send invites for')
     return InvitationService.create({
       sessionUserId: userId,
       groupId,
@@ -24,7 +25,7 @@ export async function createInvitation (userId, groupId, data) {
 export function expireInvitation (userId, invitationId) {
   return InvitationService.checkPermission(userId, invitationId)
   .then(ok => {
-    if (!ok) throw new Error("You don't have permission to modify this invitation")
+    if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
   })
   .then(() => InvitationService.expire(userId, invitationId))
   .then(() => ({success: true}))
@@ -33,7 +34,7 @@ export function expireInvitation (userId, invitationId) {
 export function resendInvitation (userId, invitationId) {
   return InvitationService.checkPermission(userId, invitationId)
   .then(ok => {
-    if (!ok) throw new Error("You don't have permission to modify this invitation")
+    if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
   })
   .then(() => InvitationService.resend(invitationId))
   .then(() => ({success: true}))
@@ -43,7 +44,7 @@ export async function reinviteAll (userId, groupId) {
   const group = await Group.find(groupId)
   return GroupMembership.hasModeratorRole(userId, group)
   .then(ok => {
-    if (!ok) throw new Error("You don't have permission to modify this invitation")
+    if (!ok) throw new GraphQLYogaError("You don't have permission to modify this invitation")
   })
   .then(() => InvitationService.reinviteAll({sessionUserId: userId, groupId}))
   .then(() => ({success: true}))

--- a/api/graphql/mutations/join_request.js
+++ b/api/graphql/mutations/join_request.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 export async function createJoinRequest (userId, groupId, questionAnswers = []) {
   if (groupId && userId) {
     const pendingRequest = await JoinRequest.where({ user_id: userId, group_id: groupId, status: JoinRequest.STATUS.Pending}).fetch()
@@ -17,7 +19,7 @@ export async function createJoinRequest (userId, groupId, questionAnswers = []) 
       return { request }
     })
   } else {
-    throw new Error(`Invalid parameters to create join request`)
+    throw new GraphQLYogaError(`Invalid parameters to create join request`)
   }
 }
 
@@ -27,10 +29,10 @@ export async function acceptJoinRequest (userId, joinRequestId) {
     if (await GroupMembership.hasModeratorRole(userId, joinRequest.get('group_id'))) {
       return joinRequest.accept(userId)
     } else {
-      throw new Error(`You do not have permission to do this`)
+      throw new GraphQLYogaError(`You do not have permission to do this`)
     }
   } else {
-    throw new Error(`Invalid parameters to accept join request`)
+    throw new GraphQLYogaError(`Invalid parameters to accept join request`)
   }
 }
 
@@ -41,10 +43,10 @@ export async function cancelJoinRequest (userId, joinRequestId) {
       await joinRequest.save({ status: JoinRequest.STATUS.Canceled })
       return { success: true }
     } else {
-      throw new Error(`You do not have permission to do this`)
+      throw new GraphQLYogaError(`You do not have permission to do this`)
     }
   } else {
-    throw new Error(`Invalid parameters to cancel join request`)
+    throw new GraphQLYogaError(`Invalid parameters to cancel join request`)
   }
 }
 
@@ -55,9 +57,9 @@ export async function declineJoinRequest (userId, joinRequestId) {
       await joinRequest.save({ status: JoinRequest.STATUS.Rejected })
       return joinRequest
     } else {
-      throw new Error(`You do not have permission to do this`)
+      throw new GraphQLYogaError(`You do not have permission to do this`)
     }
   } else {
-    throw new Error(`Invalid parameters to decline join request`)
+    throw new GraphQLYogaError(`Invalid parameters to decline join request`)
   }
 }

--- a/api/graphql/mutations/membership.js
+++ b/api/graphql/mutations/membership.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { isEmpty, mapKeys, pick, snakeCase } from 'lodash'
 
 export async function updateMembership (userId, { groupId, data, data: { settings } }) {
@@ -9,7 +10,7 @@ export async function updateMembership (userId, { groupId, data, data: { setting
   if (isEmpty(settings) && isEmpty(whitelist)) return Promise.resolve(null)
 
   const membership = await GroupMembership.forIds(userId, groupId).fetch()
-  if (!membership) throw new Error("Couldn't find membership for group with id", groupId)
+  if (!membership) throw new GraphQLYogaError("Couldn't find membership for group with id", groupId)
   if (!isEmpty(settings)) membership.addSetting(settings)
   if (!isEmpty(whitelist)) membership.set(whitelist)
   if (membership.changed) await membership.save()

--- a/api/graphql/mutations/post.js
+++ b/api/graphql/mutations/post.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 import validatePostData from '../../models/post/validatePostData'
 import underlyingCreatePost from '../../models/post/createPost'
 import underlyingUpdatePost from '../../models/post/updatePost'
@@ -18,7 +20,7 @@ export function fulfillPost (userId, postId) {
   return Post.find(postId)
     .then(post => {
       if (post.get('user_id') !== userId) {
-        throw new Error("You don't have permission to modify this post")
+        throw new GraphQLYogaError("You don't have permission to modify this post")
       }
       return post.fulfill()
     })
@@ -29,7 +31,7 @@ export function unfulfillPost (userId, postId) {
   return Post.find(postId)
     .then(post => {
       if (post.get('user_id') !== userId) {
-        throw new Error("You don't have permission to modify this post")
+        throw new GraphQLYogaError("You don't have permission to modify this post")
       }
       return post.unfulfill()
     })
@@ -45,10 +47,10 @@ export function deletePost (userId, postId) {
   return Post.find(postId)
   .then(post => {
     if (!post) {
-      throw new Error("Post does not exist")
+      throw new GraphQLYogaError("Post does not exist")
     }
     if (post.get('user_id') !== userId) {
-      throw new Error("You don't have permission to modify this post")
+      throw new GraphQLYogaError("You don't have permission to modify this post")
     }
     return Post.deactivate(postId)
   })
@@ -59,10 +61,10 @@ export async function pinPost (userId, postId, groupId) {
   const group = await Group.find(groupId)
   return GroupMembership.hasModeratorRole(userId, group)
   .then(isModerator => {
-    if (!isModerator) throw new Error("You don't have permission to modify this group")
+    if (!isModerator) throw new GraphQLYogaError("You don't have permission to modify this group")
     return PostMembership.find(postId, groupId)
     .then(postMembership => {
-      if (!postMembership) throw new Error("Couldn't find postMembership")
+      if (!postMembership) throw new GraphQLYogaError("Couldn't find postMembership")
       return postMembership.togglePinned()
     })
     .then(() => ({success: true}))

--- a/api/graphql/mutations/topic.js
+++ b/api/graphql/mutations/topic.js
@@ -1,10 +1,12 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 export async function topicMutationPermissionCheck (userId, groupId) {
   const group = await Group.find(groupId)
   if (!group) {
-    throw new Error('That group does not exist.')
+    throw new GraphQLYogaError('That group does not exist.')
   }
   if (!await GroupMembership.hasActiveMembership(userId, group)) {
-    throw new Error("You're not a member of that group.")
+    throw new GraphQLYogaError("You're not a member of that group.")
   }
 }
 
@@ -12,7 +14,7 @@ export async function createTopic (userId, topicName, groupId, isDefault, isSubs
   await topicMutationPermissionCheck(userId, groupId)
   const invalidReason = Tag.validate(topicName)
   if (invalidReason) {
-    throw new Error(invalidReason)
+    throw new GraphQLYogaError(invalidReason)
   }
 
   const topic = await Tag.findOrCreate(topicName)

--- a/api/graphql/mutations/user.js
+++ b/api/graphql/mutations/user.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 import request from 'request'
 import { decodeHyloJWT } from '../../../lib/HyloJWT'
 
@@ -57,11 +59,11 @@ export const register = (fetchOne, { req }) => async (_, { name, password }) => 
     const user = await User.find(req.session.userId, {}, false)
 
     if (!user) {
-      throw new Error('Not authorized')
+      throw new GraphQLYogaError('Not authorized')
     }
 
     if (!user.get('email_validated')) {
-      throw new Error('Email not validated')
+      throw new GraphQLYogaError('Email not validated')
     }
 
     await bookshelf.transaction(async transacting => {
@@ -167,7 +169,7 @@ export async function blockUser (userId, blockedUserId) {
 export async function unblockUser (userId, blockedUserId) {
   const blockedUser = await BlockedUser.find(userId, blockedUserId)
 
-  if (!blockedUser) throw new Error('user is not blocked')
+  if (!blockedUser) throw new GraphQLYogaError('user is not blocked')
 
   await blockedUser.destroy()
 

--- a/api/models/BlockedUser.js
+++ b/api/models/BlockedUser.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 /* eslint-disable camelcase */
 module.exports = bookshelf.Model.extend({
   tableName: 'blocked_users',
@@ -16,15 +18,15 @@ module.exports = bookshelf.Model.extend({
 
   create: function (userId, blockedUserId) {
     if (blockedUserId === User.AXOLOTL_ID) {
-      throw new Error('cannot block Hylo the Axolotl')
+      throw new GraphQLYogaError('cannot block Hylo the Axolotl')
     }
 
     if (userId === blockedUserId) {
-      throw new Error('blocked_user_id cannot equal user_id')
+      throw new GraphQLYogaError('blocked_user_id cannot equal user_id')
     }
 
     if (!userId || !blockedUserId) {
-      throw new Error('must provice a user_id and blocked_user_id')
+      throw new GraphQLYogaError('must provide a user_id and blocked_user_id')
     }
 
     return this.find(userId, blockedUserId)
@@ -42,7 +44,7 @@ module.exports = bookshelf.Model.extend({
   },
 
   find: function (user_id, blocked_user_id) {
-    if (!user_id) throw new Error('Parameter user_id must be supplied.')
+    if (!user_id) throw new GraphQLYogaError('Parameter user_id must be supplied.')
     return BlockedUser.where({user_id, blocked_user_id}).fetch()
   },
 

--- a/api/models/EventInvitation.js
+++ b/api/models/EventInvitation.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 /* eslint-disable camelcase */
 module.exports = bookshelf.Model.extend({
   tableName: 'event_invitations',
@@ -26,11 +28,11 @@ module.exports = bookshelf.Model.extend({
 
   create: function ({userId, inviterId, eventId, response}, trxOpts) {
     if (!userId) {
-      throw new Error('must provide a user_id')
+      throw new GraphQLYogaError('must provide a user_id')
     }
 
     if (!eventId) {
-      throw new Error('must provide an event_id')
+      throw new GraphQLYogaError('must provide an event_id')
     }
 
     return this.find({userId, inviterId, eventId}, trxOpts)
@@ -50,8 +52,8 @@ module.exports = bookshelf.Model.extend({
   },
 
   find: function ({ userId, inviterId, eventId }, opts) {
-    if (!userId) throw new Error('Parameter user_id must be supplied.')
-    if (!eventId) throw new Error('Parameter event_id must be supplied.')
+    if (!userId) throw new GraphQLYogaError('Parameter user_id must be supplied.')
+    if (!eventId) throw new GraphQLYogaError('Parameter event_id must be supplied.')
 
     const conditions = {
       user_id: userId,

--- a/api/models/FlaggedItem.js
+++ b/api/models/FlaggedItem.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 import { values, isEmpty, trim } from 'lodash'
 import { Validators } from 'hylo-shared'
 import { notifyModeratorsPost, notifyModeratorsMember, notifyModeratorsComment } from './flaggedItem/notifyUtils'
@@ -11,7 +13,7 @@ module.exports = bookshelf.Model.extend({
   },
 
   getObject: function () {
-    if (!this.get('object_id')) throw new Error('No object_id defined for Flagged Item')
+    if (!this.get('object_id')) throw new GraphQLYogaError('No object_id defined for Flagged Item')
     switch (this.get('object_type')) {
       case FlaggedItem.Type.POST:
         return Post.find(this.get('object_id'), {withRelated: 'groups'})
@@ -20,7 +22,7 @@ module.exports = bookshelf.Model.extend({
       case FlaggedItem.Type.MEMBER:
         return User.find(this.get('object_id'))
       default:
-        throw new Error('Unsupported type for Flagged Item', this.get('object_type'))
+        throw new GraphQLYogaError('Unsupported type for Flagged Item', this.get('object_type'))
     }
   },
 
@@ -43,7 +45,7 @@ module.exports = bookshelf.Model.extend({
       case FlaggedItem.Type.MEMBER:
         return Frontend.Route.profile(this.get('object_id'))
       default:
-        throw new Error('Unsupported type for Flagged Item', this.get('object_type'))
+        throw new GraphQLYogaError('Unsupported type for Flagged Item', this.get('object_type'))
     }
   }
 
@@ -75,7 +77,7 @@ module.exports = bookshelf.Model.extend({
     let { reason } = attrs
 
     if (!values(this.Category).find(c => category === c)) {
-      return Promise.reject(new Error('Unknown category.'))
+      return Promise.reject(new GraphQLYogaError('Unknown category.'))
     }
 
     // set reason to 'N/A' if not required (!other) and it's empty.
@@ -84,11 +86,11 @@ module.exports = bookshelf.Model.extend({
     }
 
     const invalidReason = Validators.validateFlaggedItem.reason(reason)
-    if (invalidReason) return Promise.reject(new Error(invalidReason))
+    if (invalidReason) return Promise.reject(new GraphQLYogaError(invalidReason))
 
     if (process.env.NODE_ENV !== 'development') {
       const invalidLink = Validators.validateFlaggedItem.link(link)
-      if (invalidLink) return Promise.reject(new Error(invalidLink))
+      if (invalidLink) return Promise.reject(new GraphQLYogaError(invalidLink))
     }
 
     return this.forge(attrs).save()
@@ -104,7 +106,7 @@ module.exports = bookshelf.Model.extend({
       case FlaggedItem.Type.MEMBER:
         return notifyModeratorsMember(flaggedItem)
       default:
-        throw new Error('Unsupported type for Flagged Item', flaggedItem.get('object_type'))
+        throw new GraphQLYogaError('Unsupported type for Flagged Item', flaggedItem.get('object_type'))
     }
   }
 })

--- a/api/models/Group.js
+++ b/api/models/Group.js
@@ -1,6 +1,7 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+import mbxGeocoder from '@mapbox/mapbox-sdk/services/geocoding'
 import knexPostgis from 'knex-postgis'
 import { clone, defaults, difference, flatten, intersection, isEmpty, map, merge, sortBy, pick, omit, omitBy, isUndefined, trim } from 'lodash'
-import mbxGeocoder from '@mapbox/mapbox-sdk/services/geocoding'
 import randomstring from 'randomstring'
 import wkx from 'wkx'
 import { LocationHelpers } from 'hylo-shared'
@@ -440,7 +441,7 @@ module.exports = bookshelf.Model.extend(merge({
             ge.set({ data: extData.data })
               await ge.save({}, { transacting })
           } else {
-            throw Error('Invalid extension type ' + extData.type)
+            throw new GraphQLYogaError('Invalid extension type ' + extData.type)
           }
         }
       }
@@ -488,7 +489,7 @@ module.exports = bookshelf.Model.extend(merge({
 
   validate: function () {
     if (!trim(this.get('name'))) {
-      return Promise.reject(new Error('Name cannot be blank'))
+      return Promise.reject(new GraphQLYogaError('Name cannot be blank'))
     }
 
     return Promise.resolve()
@@ -513,11 +514,11 @@ module.exports = bookshelf.Model.extend(merge({
   // ******* Class methods ******** //
   async create (userId, data) {
     if (!data.slug) {
-      throw Error("Missing required field: slug")
+      throw new GraphQLYogaError("Missing required field: slug")
     }
     const existingGroup = await Group.find(data.slug)
     if (existingGroup) {
-      throw Error("A group with that URL slug already exists")
+      throw new GraphQLYogaError("A group with that URL slug already exists")
     }
 
     var attrs = defaults(
@@ -555,7 +556,7 @@ module.exports = bookshelf.Model.extend(merge({
             const ge = new GroupExtension({ group_id: group.id, extension_id: ext.id, data: extData.data })
             await ge.save(null, { transacting: trx })
           } else {
-            throw Error('Invalid extension type ' + extData.type)
+            throw new GraphQLYogaError('Invalid extension type ' + extData.type)
           }
         }
       }

--- a/api/models/GroupRelationshipInvite.js
+++ b/api/models/GroupRelationshipInvite.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import EnsureLoad from './mixins/EnsureLoad'
 
 module.exports = bookshelf.Model.extend(Object.assign({
@@ -50,7 +51,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
     const fromGroup = await this.fromGroup().fetch({ transacting })
     if (!GroupMembership.hasModeratorRole(user, fromGroup)) {
       // The person trying to cancel the invite does not have permission
-      throw new Error('Not permitted to do this')
+      throw new GraphQLYogaError('Not permitted to do this')
     }
 
     await this.save({ canceled_by_id: userId, canceled_at: new Date(), status: GroupRelationshipInvite.STATUS.Canceled },
@@ -70,7 +71,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
     const toGroup = await this.toGroup().fetch({ transacting })
     if (!GroupMembership.hasModeratorRole(user, toGroup)) {
       // The person trying to process the invite does not have permission
-      throw new Error('Not permitted to do this')
+      throw new GraphQLYogaError('Not permitted to do this')
     }
     const fromGroup = await this.fromGroup().fetch({ transacting })
     const parentGroup = (this.get('type') === GroupRelationshipInvite.TYPE.ParentToChild) ? fromGroup : toGroup

--- a/api/models/JoinRequest.js
+++ b/api/models/JoinRequest.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 module.exports = bookshelf.Model.extend({
   tableName: 'join_requests',
   requireFetch: false,
@@ -34,7 +36,7 @@ module.exports = bookshelf.Model.extend({
       })
       return this
     }
-    throw new Error("Invalid join request")
+    throw new GraphQLYogaError("Invalid join request")
   }
 }, {
 

--- a/api/models/LinkedAccount.js
+++ b/api/models/LinkedAccount.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import bcrypt from 'bcrypt'
 import Promise from 'bluebird'
 import { get, isEmpty } from 'lodash'
@@ -30,7 +31,7 @@ module.exports = bookshelf.Model.extend({
   create: function (userId, { type, profile, password, token }, { transacting, updateUser } = {}) {
     if (type === 'password') {
       const invalidReason = Validators.validateUser.password(password)
-      if (invalidReason) return Promise.reject(new Error(invalidReason))
+      if (invalidReason) return Promise.reject(new GraphQLYogaError(invalidReason))
     }
 
     return (() =>

--- a/api/models/UserConnection.js
+++ b/api/models/UserConnection.js
@@ -1,3 +1,5 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 /* eslint-disable camelcase */
 module.exports = bookshelf.Model.extend({
   tableName: 'user_connections',
@@ -18,10 +20,10 @@ module.exports = bookshelf.Model.extend({
 
   create: function (userId, otherUserId, type) {
     if (!this.Type.hasOwnProperty(type.toUpperCase())) {
-      throw new Error('Invalid UserConnection type specified')
+      throw new GraphQLYogaError('Invalid UserConnection type specified')
     }
     if (userId === otherUserId) {
-      throw new Error('other_user_id cannot equal user_id')
+      throw new GraphQLYogaError('other_user_id cannot equal user_id')
     }
     return new UserConnection({
       user_id: userId,
@@ -45,7 +47,7 @@ module.exports = bookshelf.Model.extend({
   },
 
   find: function (user_id, other_user_id, type) {
-    if (!user_id) throw new Error('Parameter user_id must be supplied.')
+    if (!user_id) throw new GraphQLYogaError('Parameter user_id must be supplied.')
     return UserConnection.where({ user_id, other_user_id, type }).fetch()
   },
 

--- a/api/models/comment/updateComment.js
+++ b/api/models/comment/updateComment.js
@@ -1,12 +1,13 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { difference, uniq } from 'lodash'
 import { updateMedia } from './util'
 
 export default async function updateComment (commenterId, id, params) {
-  if (!id) throw new Error('updateComment called with no ID')
+  if (!id) throw new GraphQLYogaError('updateComment called with no ID')
 
   const comment = await Comment.find(id, { withRelated: ['post', 'media'] })
 
-  if (!comment) throw new Error('cannot find comment with ID', id)
+  if (!comment) throw new GraphQLYogaError('cannot find comment with ID', id)
 
   let { text, attachments } = params
 

--- a/api/models/post/findOrCreateThread.js
+++ b/api/models/post/findOrCreateThread.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { pick } from 'lodash'
 import { map, uniq } from 'lodash/fp'
 import { isFollowing } from '../group/queryUtils'
@@ -26,12 +27,12 @@ export async function createThread (userId, participantIds) {
 export function validateThreadData (userId, data) {
   const { participantIds } = data
   if (!(participantIds && participantIds.length)) {
-    throw new Error("participantIds can't be empty")
+    throw new GraphQLYogaError("participantIds can't be empty")
   }
   const checkForSharedGroup = id =>
     Group.inSameGroup([userId, id])
     .then(doesShare => {
-      if (!doesShare) throw new Error(`no shared communities with user ${id}`)
+      if (!doesShare) throw new GraphQLYogaError(`no shared groups with user ${id}`)
     })
   return Promise.all(map(checkForSharedGroup, participantIds))
 }

--- a/api/models/post/updatePost.js
+++ b/api/models/post/updatePost.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import setupPostAttrs from './setupPostAttrs'
 import updateChildren from './updateChildren'
 import {
@@ -7,11 +8,11 @@ import {
 } from './util'
 
 export default function updatePost (userId, id, params) {
-  if (!id) throw new Error('updatePost called with no ID')
+  if (!id) throw new GraphQLYogaError('updatePost called with no ID')
   return setupPostAttrs(userId, params)
   .then(attrs => bookshelf.transaction(transacting =>
     Post.find(id).then(post => {
-      if (!post) throw new Error('Post not found')
+      if (!post) throw new GraphQLYogaError('Post not found')
       const updatableTypes = [
         Post.Type.OFFER,
         Post.Type.PROJECT,
@@ -22,7 +23,7 @@ export default function updatePost (userId, id, params) {
         null
       ]
       if (!updatableTypes.includes(post.get('type'))) {
-        throw new Error("This post can't be modified")
+        throw new GraphQLYogaError("This post can't be modified")
       }
 
       return post.save(attrs, {patch: true, transacting})

--- a/api/models/post/validatePostData.js
+++ b/api/models/post/validatePostData.js
@@ -1,23 +1,24 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { includes, isEmpty, trim } from 'lodash'
 
 export default function validatePostData (userId, data) {
   if (!trim(data.name)) {
-    throw new Error('title can\'t be blank')
+    throw new GraphQLYogaError('title can\'t be blank')
   }
 
   const allowedTypes = [Post.Type.REQUEST, Post.Type.OFFER, Post.Type.DISCUSSION, Post.Type.PROJECT, Post.Type.EVENT, Post.Type.RESOURCE]
   if (data.type && !includes(allowedTypes, data.type)) {
-    throw new Error('not a valid type')
+    throw new GraphQLYogaError('not a valid type')
   }
 
   if (isEmpty(data.group_ids)) {
-    throw new Error('no communities specified')
+    throw new GraphQLYogaError('no groups specified')
   }
 
   if (data.topicNames && data.topicNames.length > 3) {
-    throw new Error('too many topics in post, maximum 3')
+    throw new GraphQLYogaError('too many topics in post, maximum 3')
   }
 
   return Group.allHaveMember(data.group_ids, userId)
-    .then(ok => ok ? Promise.resolve() : Promise.reject(new Error('unable to post to all those communities')))
+    .then(ok => ok ? Promise.resolve() : Promise.reject(new GraphQLYogaError('unable to post to all those groups')))
 }

--- a/api/models/post/validatePostData.test.js
+++ b/api/models/post/validatePostData.test.js
@@ -28,14 +28,14 @@ describe('validatePostData', () => {
 
   it('fails if no group_ids are provided', () => {
     const fn = () => validatePostData(null, {name: 't'})
-    expect(fn).to.throw(/no communities specified/)
+    expect(fn).to.throw(/no groups specified/)
   })
 
   it('fails if there is a group_id for a group user is not a member of', () => {
     const data = {name: 't', group_ids: [inGroup.id, notInGroup.id]}
     return validatePostData(user.id, data)
     .catch(function (e) {
-      expect(e.message).to.match(/unable to post to all those communities/)
+      expect(e.message).to.match(/unable to post to all those groups/)
     })
   })
 
@@ -52,7 +52,7 @@ describe('validatePostData', () => {
     expect(fn).to.throw(/too many topics in post, maximum 3/)
   })
 
-  it('continues the promise chain if name is provided and user is member of communities', () => {
+  it('continues the promise chain if name is provided and user is member of groups', () => {
     const data = {name: 't', group_ids: [inGroup.id]}
     return validatePostData(user.id, data)
     .catch(() => expect.fail('should resolve'))

--- a/api/policies/checkAndDecodeToken.js
+++ b/api/policies/checkAndDecodeToken.js
@@ -1,9 +1,11 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
+
 module.exports = function checkAndDecodeToken (req, res, next) {
   const token = req.param('token')
   try {
     res.locals.tokenData = Email.decodeFormToken(token)
     next()
   } catch (e) {
-    res.badRequest(new Error('Invalid token: ' + token))
+    res.badRequest(new GraphQLYogaError('Invalid token: ' + token))
   }
 }

--- a/api/services/InvitationService.js
+++ b/api/services/InvitationService.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import validator from 'validator'
 import { TextHelpers } from 'hylo-shared'
 import { get, isEmpty, map, merge } from 'lodash/fp'
@@ -6,7 +7,7 @@ module.exports = {
   checkPermission: (userId, invitationId) => {
     return Invitation.find(invitationId, {withRelated: 'group'})
     .then(async (invitation) => {
-      if (!invitation) throw new Error('Invitation not found')
+      if (!invitation) throw new GraphQLYogaError('Invitation not found')
       const { group } = invitation.relations
       const user = await User.find(userId)
       return user.get('email') === invitation.get('email') || GroupMembership.hasModeratorRole(userId, group)
@@ -132,7 +133,7 @@ module.exports = {
   expire: (userId, invitationId) => {
     return Invitation.find(invitationId)
     .then(invitation => {
-      if (!invitation) throw new Error('not found')
+      if (!invitation) throw new GraphQLYogaError('not found')
 
       return invitation.expire(userId)
     })
@@ -141,7 +142,7 @@ module.exports = {
   resend: (invitationId) => {
     return Invitation.find(invitationId)
     .then(invitation => {
-      if (!invitation) throw new Error('not found')
+      if (!invitation) throw new GraphQLYogaError('not found')
 
       return invitation.send()
     })
@@ -187,8 +188,8 @@ module.exports = {
     if (token) {
       return Invitation.where({token}).fetch()
       .then(invitation => {
-        if (!invitation) throw new Error('not found')
-        if (invitation.isExpired()) throw new Error('expired')
+        if (!invitation) throw new GraphQLYogaError('not found')
+        if (invitation.isExpired()) throw new GraphQLYogaError('expired')
         return invitation.use(userId)
       })
     }

--- a/api/services/Search/forUsers.js
+++ b/api/services/Search/forUsers.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { countTotal } from '../../../lib/util/knex'
 import { filterAndSortUsers } from './util'
 
@@ -17,7 +18,7 @@ export default function (opts) {
 
     if (opts.sort === 'join') {
       if (!groups || groups.length !== 1) {
-        throw new Error('When sorting by join date, you must specify exactly one community.')
+        throw new GraphQLYogaError('When sorting by join date, you must specify exactly one group.')
       }
     }
 

--- a/lib/graphql-bookshelf-bridge/util/applyPagination.js
+++ b/lib/graphql-bookshelf-bridge/util/applyPagination.js
@@ -1,3 +1,4 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { countTotal } from '../../../lib/util/knex'
 import { snakeCase } from 'lodash'
 
@@ -7,11 +8,11 @@ export default function applyPagination (query, tableName, opts) {
   const { first, cursor, order, offset, sortBy = 'id' } = opts
 
   if (cursor && offset) {
-    throw new Error('Specifying both cursor and offset is not supported.')
+    throw new GraphQLYogaError('Specifying both cursor and offset is not supported.')
   }
 
   if (cursor && sortBy !== 'id') {
-    throw new Error('Specifying both cursor and sortBy is not supported.')
+    throw new GraphQLYogaError('Specifying both cursor and sortBy is not supported.')
   }
 
   // skip special sorts

--- a/lib/uploader/validation.js
+++ b/lib/uploader/validation.js
@@ -1,17 +1,18 @@
+const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { values } from 'lodash'
 import * as types from './types'
 
 export function validate ({ type, id, userId, url, stream }) {
   if (!values(types).includes(type)) {
-    return Promise.reject(new Error('Validation error: Invalid type'))
+    return Promise.reject(new GraphQLYogaError('Validation error: Invalid type'))
   }
 
   if (!url && !stream) {
-    return Promise.reject(new Error('Validation error: No url and no stream'))
+    return Promise.reject(new GraphQLYogaError('Validation error: No url and no stream'))
   }
 
   if (!id) {
-    return Promise.reject(new Error('Validation error: No id'))
+    return Promise.reject(new GraphQLYogaError('Validation error: No id'))
   }
 
   return hasPermission(userId, type, id)
@@ -20,14 +21,14 @@ export function validate ({ type, id, userId, url, stream }) {
 async function hasPermission (userId, type, id) {
   if (type.startsWith('user')) {
     if (id === userId) return Promise.resolve()
-    return Promise.reject(new Error('Validation error: Not allowed to change settings for another person'))
+    return Promise.reject(new GraphQLYogaError('Validation error: Not allowed to change settings for another person'))
   }
 
   if (type.startsWith('group')) {
     const group = await Group.find(id)
     if (!group ||
       !(await GroupMembership.hasModeratorRole(userId, group))) {
-      throw new Error('Validation error: Not a moderator of this group')
+      throw new GraphQLYogaError('Validation error: Not a moderator of this group')
     }
   }
 
@@ -35,7 +36,7 @@ async function hasPermission (userId, type, id) {
     if (id === 'new') return Promise.resolve()
     return Post.find(id)
     .then(post => {
-      if (!post || post.get('user_id') !== userId) throw new Error('Validation error: Not allowed to edit this post')
+      if (!post || post.get('user_id') !== userId) throw new GraphQLYogaError('Validation error: Not allowed to edit this post')
     })
   }
 }

--- a/test/unit/models/BlockedUser.test.js
+++ b/test/unit/models/BlockedUser.test.js
@@ -21,7 +21,7 @@ describe('BlockedUser', () => {
 
     it('throws if user_id is null', () => {
       expect(() => BlockedUser.create(null, '1'))
-        .to.throw(/must provice a user_id and blocked_user_id/)
+        .to.throw(/must provide a user_id and blocked_user_id/)
     })
 
     it('creates a BlockedUser', () => {


### PR DESCRIPTION
Works with graphql-yoga's error masking feature to hide error messages from front-end and not reveal dangerous secrets accidentally