### PR TITLE
Add allow_in_public column to groups

### DIFF
--- a/api/controllers/PostController.js
+++ b/api/controllers/PostController.js
@@ -44,11 +44,14 @@ const PostController = {
         }
       }))
     .then(stop => stop || createPost(userId, attributes)
-      .tap(() => Analytics.track({
-        userId,
-        event: 'Add Post by Email Form',
-        properties: {group: group.get('name')}
-      }))
+      .then(post => {
+        Analytics.track({
+          userId,
+          event: 'Add Post by Email Form',
+          properties: {group: group.get('name')}
+        })
+        return post
+      })
       .then(post => res.redirect(Frontend.Route.post(post, group))))
     .catch(res.serverError)
   },

--- a/api/models/Group.js
+++ b/api/models/Group.js
@@ -534,7 +534,7 @@ module.exports = bookshelf.Model.extend(merge({
       throw new GraphQLYogaError("A group with that URL slug already exists")
     }
 
-    var attrs = defaults(
+    let attrs = defaults(
       pick(data,
         'about_video_uri', 'accessibility', 'avatar_url', 'description', 'slug', 'category',
         'access_code', 'banner_url', 'location_id', 'location', 'group_data_type', 'moderator_descriptor',
@@ -548,6 +548,11 @@ module.exports = bookshelf.Model.extend(merge({
         'visibility': Group.Visibility.PROTECTED
       }
     )
+
+    // XXX: temporary, by default show all farms in public. These can only be created via API right now
+    if (attrs.type === 'farm') {
+      attrs.allow_in_public = true
+    }
 
     // eslint-disable-next-line camelcase
     const access_code = attrs.access_code || await Group.getNewAccessCode()

--- a/api/models/post/createPost.js
+++ b/api/models/post/createPost.js
@@ -5,6 +5,7 @@ import { groupRoom, pushToSockets } from '../../services/Websockets'
 
 export default async function createPost (userId, params) {
   if (params.isPublic) {
+    // Don't allow creating a public post unless at least one of the post's groups has allow_in_public set to true
     const groups = await Group.query(q => q.whereIn('id', params.group_ids)).fetchAll()
     const allowedToMakePublic = groups.find(g => g.get('allow_in_public'))
     if (!allowedToMakePublic) params.isPublic = false

--- a/api/models/post/createPost.js
+++ b/api/models/post/createPost.js
@@ -3,18 +3,24 @@ import setupPostAttrs from './setupPostAttrs'
 import updateChildren from './updateChildren'
 import { groupRoom, pushToSockets } from '../../services/Websockets'
 
-export default function createPost (userId, params) {
+export default async function createPost (userId, params) {
+  if (params.isPublic) {
+    const groups = await Group.query(q => q.whereIn('id', params.group_ids)).fetchAll()
+    const allowedToMakePublic = groups.find(g => g.get('allow_in_public'))
+    if (!allowedToMakePublic) params.isPublic = false
+  }
+
   return setupPostAttrs(userId, merge(Post.newPostAttrs(), params))
-  .then(attrs => bookshelf.transaction(transacting =>
-    Post.create(attrs, { transacting })
-    .tap(post => afterCreatingPost(post, merge(
-      pick(params, 'group_ids', 'imageUrl', 'videoUrl', 'docs', 'topicNames', 'memberIds', 'eventInviteeIds', 'imageUrls', 'fileUrls', 'announcement', 'location', 'location_id'),
-      {children: params.requests, transacting}
-    )))).then(function(inserts) {
-      return inserts
-    }).catch(function(error) {
-      throw error
-    })
+    .then(attrs => bookshelf.transaction(transacting =>
+      Post.create(attrs, { transacting })
+        .tap(post => afterCreatingPost(post, merge(
+          pick(params, 'group_ids', 'imageUrl', 'videoUrl', 'docs', 'topicNames', 'memberIds', 'eventInviteeIds', 'imageUrls', 'fileUrls', 'announcement', 'location', 'location_id'),
+          {children: params.requests, transacting}
+      )))).then(function(inserts) {
+        return inserts
+      }).catch(function(error) {
+        throw error
+      })
   )
 }
 

--- a/api/models/post/setupPostAttrs.js
+++ b/api/models/post/setupPostAttrs.js
@@ -4,7 +4,6 @@ import { getOr } from 'lodash/fp'
 export default function setupPostAttrs (userId, params) {
   const attrs = merge({
     user_id: userId,
-    visibility: params.public ? Post.Visibility.PUBLIC_READABLE : Post.Visibility.DEFAULT,
     link_preview_id: params.link_preview_id || getOr(null, 'id', params.linkPreview),
     parent_post_id: params.parent_post_id,
     updated_at: new Date(),

--- a/migrations/20221110125837_show-in-public-flag-to-groups.js
+++ b/migrations/20221110125837_show-in-public-flag-to-groups.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('groups', table => {
+    table.boolean('allow_in_public').defaultTo(false)
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.table('groups', table => {
+    table.dropColumn('allow_in_public')
+  })
+}

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1042,7 +1042,8 @@ CREATE TABLE public.groups (
     type_descriptor_plural character varying(255) DEFAULT NULL::character varying,
     moderator_descriptor character varying(255) DEFAULT NULL::character varying,
     moderator_descriptor_plural character varying(255) DEFAULT NULL::character varying,
-    about_video_uri character varying(255)
+    about_video_uri character varying(255),
+    allow_in_public boolean DEFAULT false
 );
 
 


### PR DESCRIPTION
When off then people are not allowed to create public posts from that group. Meaning a post that is chosen to be public must also be posted in at least one group that has allow_in_public set to true.

Fixes https://github.com/Hylozoic/hylo-node/issues/889