### PR TITLE
Fixing public groups and hopefully sessions

### DIFF
--- a/api/models/Group.js
+++ b/api/models/Group.js
@@ -557,10 +557,8 @@ module.exports = bookshelf.Model.extend(merge({
       }
     )
 
-    // XXX: temporary, by default show all farms in public. These can only be created via API right now
-    if (attrs.type === 'farm') {
-      attrs.allow_in_public = true
-    }
+    // XXX: for now allow all groups to appear in public by default
+    attrs.allow_in_public = true
 
     // eslint-disable-next-line camelcase
     const access_code = attrs.access_code || await Group.getNewAccessCode()

--- a/api/models/Invitation.js
+++ b/api/models/Invitation.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid'
+import { v4 as uuidv4 } from 'uuid'
 import EnsureLoad from './mixins/EnsureLoad'
 
 module.exports = bookshelf.Model.extend(Object.assign({
@@ -129,7 +129,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
       email: opts.email.toLowerCase(),
       tag_id: opts.tagId,
       role: GroupMembership.Role[opts.moderator ? 'MODERATOR' : 'DEFAULT'],
-      token: uuid.v4(),
+      token: uuidv4(),
       created_at: new Date(),
       subject: opts.subject,
       message: opts.message

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -3,7 +3,7 @@ import bcrypt from 'bcrypt'
 import crypto from 'crypto'
 const { GraphQLYogaError } = require('@graphql-yoga/node')
 import { has, isEmpty, merge, omit, pick, intersectionBy } from 'lodash'
-import uuid from 'node-uuid'
+import { v4 as uuidv4 } from 'uuid'
 import validator from 'validator'
 import { Validators } from 'hylo-shared'
 import HasSettings from './mixins/HasSettings'
@@ -314,7 +314,7 @@ module.exports = bookshelf.Model.extend(merge({
     location_id = NULL,
     contact_email = NULL,
     contact_phone = NULL,
-    email = '${uuid.v4()}@hylo.com',
+    email = '${uuidv4()}@hylo.com',
     first_name = NULL,
     last_name = NULL,
     twitter_name = NULL,

--- a/api/services/Analytics.js
+++ b/api/services/Analytics.js
@@ -1,5 +1,5 @@
 const sails = require('sails')
-const uuid = require('node-uuid')
+import { v4 as uuidv4 } from 'uuid'
 var instance
 
 if (process.env.NODE_ENV === 'test') {
@@ -24,7 +24,7 @@ instance.pixelUrl = function (emailName, props) {
   if (props.userId) {
     data.userId = props.userId
   } else {
-    data.anonymousId = uuid.v4()
+    data.anonymousId = uuidv4()
   }
 
   var encodedData = Buffer.from(JSON.stringify(data), 'utf8').toString('base64')

--- a/config/session.js
+++ b/config/session.js
@@ -1,4 +1,4 @@
-const uuid = require('node-uuid')
+const { v4: uuidv4 } = require('uuid')
 
 /**
  * Session Configuration
@@ -27,7 +27,7 @@ module.exports.session = {
 
   genid: function(req) {
     // use UUIDs for session IDs prefixed by userId so we can find and clear all sessions for this user on password change
-    return (req.userId || 'anon') + ":" + uuid.v4()
+    return (req.userId || 'anon') + ":" + uuidv4()
   },
 
   /***************************************************************************

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "minimist": "^1.1.0",
     "moment-timezone": "^0.5.37",
     "newrelic": "^7.0.0",
-    "node-uuid": "^1.4.8",
     "oidc-provider": "^7.11.0",
     "parse-redis-url": "0.0.2",
     "passport": "^0.2.1",
@@ -161,6 +160,7 @@
     "tar-stream": "^1.2.1",
     "unist-util-inspect": "^4.1.3",
     "unist-util-visit": "^1.3.1",
+    "uuid": "^9.0.0",
     "validator": "^3.22.1",
     "wkx": "^0.5.0"
   },

--- a/seeds/farm-demo/demo-farms.js
+++ b/seeds/farm-demo/demo-farms.js
@@ -17,7 +17,7 @@ const {
   PRODUCT_CATAGORIES,
   PUBLIC_OFFERINGS
 } = require('../../lib/constants')
-const uuid = require('node-uuid')
+const { v4: uuidv4 } = require('uuid')
 
 const farmNames = [
   'Luna Farm',
@@ -264,7 +264,7 @@ function generateFakeFarmData (index) {
     role: null, // left null
     schema_version: '0.2',
     social: `${faker.random.word()}.com`,
-    unique_id: uuid.v4(),
+    unique_id: uuidv4(),
     units: Math.random() > 0.85 ? null : Math.random() > 0.5 ? 'imperial' : 'metric',
     website: Math.random() > 0.8 ? null : `${faker.random.word()}-farm.com`
   }

--- a/seeds/farm-dev/add-farm-groups.js
+++ b/seeds/farm-dev/add-farm-groups.js
@@ -18,7 +18,7 @@ const {
   PRODUCT_CATAGORIES,
   PUBLIC_OFFERINGS,
 } = require('../../lib/constants')
-const uuid = require('node-uuid')
+const { v4: uuidv4 } = require('uuid')
 
 exports.seed = (knex) => seed('locations', knex)
   .then(() => seed('users', knex))
@@ -339,7 +339,7 @@ function generateFakeFarmData (index) {
     role: null, // left null
     schema_version: '0.2',
     social: `${faker.random.word()}.com`,
-    unique_id: uuid.v4(),
+    unique_id: uuidv4(),
     units: Math.random() > 0.85 ? null : Math.random() > 0.5 ? 'imperial' : 'metric',
     website: Math.random() > 0.8 ? null : `${faker.random.word()}-farm.com`
   }
@@ -458,7 +458,7 @@ function fakeGroupData (name, slug, created_by_id, type) {
 
 function fakeUser () {
   return Promise.resolve({
-    email: `${uuid.v4()}@farm-demo.com`,
+    email: `${uuidv4()}@farm-demo.com`,
     name: `${faker.name.firstName()} ${faker.name.lastName()}`,
     avatar_url: `https://avatars.dicebear.com/api/open-peeps/${faker.random.word()}.svg`,
     first_name: faker.name.firstName(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9324,11 +9324,6 @@ node-rsa@^1.1.1:
   dependencies:
     asn1 "^0.2.4"
 
-node-uuid@^1.4.8:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
-  integrity sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA==
-
 nodemon@^1.12.1:
   version "1.19.4"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.19.4.tgz#56db5c607408e0fdf8920d2b444819af1aae0971"
@@ -13701,6 +13696,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
We decided to let all new groups back into the public context, for now. 

And this upgrades old deprecated node-uuid package to newer uuid as a shot in the dark hope that the reason a couple folks have gotten logged in as others is due to duplicate uuid sessions being generated? Also probably good for security to not be using deprecated packages