### PR TITLE
Make sure all notifications work with chat posts and comments

### DIFF
--- a/api/models/Activity.js
+++ b/api/models/Activity.js
@@ -248,9 +248,9 @@ module.exports = bookshelf.Model.extend({
 
   groupIds: function (activity) {
     if (activity.get('post_id')) {
-      return get(activity, 'relations.post.relations.groups', []).map(c => c.id)
+      return get(activity, 'relations.post.relations.groups', []).map(g => g.id)
     } else if (activity.get('comment_id')) {
-      return get(activity, 'relations.comment.relations.post.relations.groups', []).map(c => c.id)
+      return get(activity, 'relations.comment.relations.post.relations.groups', []).map(g => g.id)
     } else if (activity.get('group_id')) {
       // For group to group join requests/invites other group is the one related to the reader of the notification
       return activity.get('other_group_id') ? [activity.relations.group.id, activity.relations.otherGroup.id] : [activity.relations.group.id]

--- a/api/models/FlaggedItem.js
+++ b/api/models/FlaggedItem.js
@@ -41,7 +41,7 @@ module.exports = bookshelf.Model.extend({
         return Frontend.Route.post(this.get('object_id'), group, isPublic)
       case FlaggedItem.Type.COMMENT:
         const comment = await this.getObject()
-        return Frontend.Route.comment({ comment, group })
+        return Frontend.Route.comment({ comment, groupSlug: group ? group.get('slug') : null })
       case FlaggedItem.Type.MEMBER:
         return Frontend.Route.profile(this.get('object_id'))
       default:

--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -404,7 +404,6 @@ module.exports = bookshelf.Model.extend({
   // version corresponds to names of versions in SendWithUs
   // XXX: This is not used right now, we send Comment Digests instead
   sendCommentNotificationEmail: function (version) {
-
     const comment = this.comment()
     const reader = this.reader()
     if (!comment) return

--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -350,7 +350,7 @@ module.exports = bookshelf.Model.extend({
           post_user_profile_url: Frontend.Route.tokenLogin(reader, token,
             Frontend.Route.profile(user) + '?ctt=announcement_email&cti=' + reader.id),
           post_description: RichText.qualifyLinks(post.details(), group.get('slug')),
-          post_title: decode(post.get('name')),
+          post_title: decode(post.summary()),
           post_url: Frontend.Route.tokenLogin(reader, token,
             Frontend.Route.post(post, group) + '?ctt=announcement_email&cti=' + reader.id),
           unfollow_url: Frontend.Route.tokenLogin(reader, token,
@@ -362,13 +362,16 @@ module.exports = bookshelf.Model.extend({
   },
 
   sendPostMentionEmail: function () {
-    var post = this.post()
-    var reader = this.reader()
-    var user = post.relations.user
-    var replyTo = Email.postReplyAddress(post.id, reader.id)
+    const post = this.post()
+    const reader = this.reader()
+    const user = post.relations.user
+    const tags =  post.relations.tags
+    const firstTag =  tags && tags.first()?.get('name')
+    const replyTo = Email.postReplyAddress(post.id, reader.id)
 
-    var groupIds = Activity.groupIds(this.relations.activity)
+    const groupIds = Activity.groupIds(this.relations.activity)
     if (isEmpty(groupIds)) throw new Error('no group ids in activity')
+
     return Group.find(groupIds[0])
     .then(group => reader.generateToken()
       .then(token => Email.sendPostMentionNotification({
@@ -387,10 +390,10 @@ module.exports = bookshelf.Model.extend({
           post_user_profile_url: Frontend.Route.tokenLogin(reader, token,
             Frontend.Route.profile(user) + '?ctt=post_mention_email&cti=' + reader.id),
           post_description: RichText.qualifyLinks(post.details(), group.get('slug')),
-          post_title: decode(post.get('name')),
+          post_title: post.get('type') === Post.Type.CHAT ? '#' + firstTag : decode(post.summary()),
           post_type: post.get('type'),
           post_url: Frontend.Route.tokenLogin(reader, token,
-            Frontend.Route.post(post) + '?ctt=post_mention_email&cti=' + reader.id),
+            Frontend.Route.post(post, group, false, firstTag) + '?ctt=post_mention_email&cti=' + reader.id),
           unfollow_url: Frontend.Route.tokenLogin(reader, token,
             Frontend.Route.unfollow(post, group) + '?ctt=post_mention_email&cti=' + reader.id),
           tracking_pixel_url: Analytics.pixelUrl('Mention in Post', {userId: reader.id})
@@ -399,7 +402,9 @@ module.exports = bookshelf.Model.extend({
   },
 
   // version corresponds to names of versions in SendWithUs
+  // XXX: This is not used right now, we send Comment Digests instead
   sendCommentNotificationEmail: function (version) {
+
     const comment = this.comment()
     const reader = this.reader()
     if (!comment) return
@@ -407,7 +412,7 @@ module.exports = bookshelf.Model.extend({
     const post = comment.relations.post
     const commenter = comment.relations.user
     const replyTo = Email.postReplyAddress(post.id, reader.id)
-    const title = decode(post.get('name'))
+    const title = decode(post.summary())
 
     var postLabel = `"${title}"`
     if (post.get('type') === 'welcome') {
@@ -613,9 +618,9 @@ module.exports = bookshelf.Model.extend({
     const token = await reader.generateToken()
     return Email.sendDonationToEmail({
       email: reader.get('email'),
-      sender: {name: project.get('name')},
+      sender: {name: project.summary()},
       data: {
-        project_title: project.get('name'),
+        project_title: project.summary(),
         project_url: Frontend.Route.tokenLogin(reader, token,
           Frontend.Route.post(project) + '?ctt=post_mention_email&cti=' + reader.id),
         contribution_amount: projectContribution.get('amount') / 100,
@@ -636,9 +641,9 @@ module.exports = bookshelf.Model.extend({
     const token = await reader.generateToken()
     return Email.sendDonationFromEmail({
       email: reader.get('email'),
-      sender: {name: project.get('name')},
+      sender: {name: project.summary()},
       data: {
-        project_title: project.get('name'),
+        project_title: project.summary(),
         project_url: Frontend.Route.tokenLogin(reader, token,
           Frontend.Route.post(project) + '?ctt=post_mention_email&cti=' + reader.id),
         contribution_amount: projectContribution.get('amount') / 100,
@@ -676,7 +681,7 @@ module.exports = bookshelf.Model.extend({
           post_user_profile_url: Frontend.Route.tokenLogin(reader, token,
             Frontend.Route.profile(inviter) + '?ctt=post_mention_email&cti=' + reader.id),
           post_description: RichText.qualifyLinks(post.details(), group.get('slug')),
-          post_title: decode(post.get('name')),
+          post_title: decode(post.summary()),
           post_type: 'event',
           post_date: post.prettyEventDates(post.get('start_time'), post.get('end_time')),
           post_url: Frontend.Route.tokenLogin(reader, token,
@@ -764,6 +769,7 @@ module.exports = bookshelf.Model.extend({
     return Notification.findUnsent({withRelated: [
       'activity',
       'activity.post',
+      'activity.post.tags',
       'activity.post.groups',
       'activity.post.user',
       'activity.comment',

--- a/api/models/PushNotification.js
+++ b/api/models/PushNotification.js
@@ -44,7 +44,7 @@ module.exports = bookshelf.Model.extend({
 }, {
   textForContribution: function (contribution) {
     const post = contribution.relations.post
-    return `You have been added as a contributor to the request "${post.get('name')}"`
+    return `You have been added as a contributor to the request "${post.summary()}"`
   },
 
   textForComment: function (comment, version) {
@@ -54,7 +54,7 @@ module.exports = bookshelf.Model.extend({
       return `${person} sent an image`
     }
     const blurb = TextHelpers.presentHTMLToText(comment.text(), { truncate: 140 })
-    const postName = comment.relations.post.get('name')
+    const postName = comment.relations.post.summary()
 
     return version === 'mention'
       ? `${person} mentioned you: "${blurb}" (in "${postName}")`
@@ -63,7 +63,7 @@ module.exports = bookshelf.Model.extend({
 
   textForPost: function (post, group, userId, version) {
     const person = post.relations.user.get('name')
-    const postName = decode(post.get('name'))
+    const postName = decode(post.summary())
 
     return version === 'mention'
       ? `${person} mentioned you in "${postName}"`
@@ -72,13 +72,13 @@ module.exports = bookshelf.Model.extend({
 
   textForAnnouncement: function (post) {
     const person = post.relations.user.get('name')
-    const postName = decode(post.get('name'))
+    const postName = decode(post.summary())
 
     return `${person} sent an announcement titled "${postName}"`
   },
 
   textForEventInvitation: function (post, actor) {
-    const postName = decode(post.get('name'))
+    const postName = decode(post.summary())
 
     return `${actor.get('name')} invited you to "${postName}"`
   },
@@ -133,7 +133,7 @@ module.exports = bookshelf.Model.extend({
 
   textForDonationTo: function (contribution) {
     const project = contribution.relations.project
-    const postName = decode(project.get('name'))
+    const postName = decode(project.summary())
     const amount = contribution.get('amount') / 100
 
     return `You contributed $${amount} to "${postName}"`
@@ -142,7 +142,7 @@ module.exports = bookshelf.Model.extend({
   textForDonationFrom: function (contribution) {
     const actor = contribution.relations.user
     const project = contribution.relations.project
-    const postName = decode(project.get('name'))
+    const postName = decode(project.summary())
 
     const amount = contribution.get('amount') / 100
     return `${actor.get('name')} contributed $${amount} to "${postName}"`

--- a/api/models/comment/notifications.js
+++ b/api/models/comment/notifications.js
@@ -48,6 +48,7 @@ export const sendDigests = async () => {
         q.orderBy('created_at', 'asc')
       }},
       'user',
+      'groups',
       'comments.user',
       'comments.media'
     ]})
@@ -57,6 +58,7 @@ export const sendDigests = async () => {
     if (comments.length === 0) return []
 
     const followers = await post.followers().fetch()
+    const firstGroup = post.relations.groups.first()
 
     return Promise.map(followers.models, user => {
       // select comments not written by this user and newer than user's last
@@ -120,7 +122,7 @@ export const sendDigests = async () => {
             count: commentData.length,
             post_title: post.summary(),
             post_creator_avatar_url: post.relations.user.get('avatar_url'),
-            thread_url: Frontend.Route.comment({ comment: commentData[0], post }),
+            thread_url: Frontend.Route.comment({ comment: commentData[0], groupSlug: firstGroup.get('slug'), post }),
             comments: commentData,
             subject_prefix: some(hasMention, commentData)
               ? 'You were mentioned in'

--- a/api/models/comment/notifications.js
+++ b/api/models/comment/notifications.js
@@ -72,6 +72,7 @@ export const sendDigests = async () => {
 
       const presentComment = comment => {
         const presented = {
+          id: comment.id,
           name: comment.relations.user.get('name'),
           avatar_url: comment.relations.user.get('avatar_url')
         }

--- a/api/services/Frontend.js
+++ b/api/services/Frontend.js
@@ -131,14 +131,14 @@ module.exports = {
       return url(`/members/${getModelId(user)}`)
     },
 
-    post: function (post, group, isPublic) {
+    post: function (post, group, isPublic, topic) {
       let groupSlug = getSlug(group)
       let groupUrl = '/all'
 
       if (isPublic) {
         groupUrl = '/public'
       } else if (!isEmpty(groupSlug)) {
-        groupUrl = `/groups/${groupSlug}`
+        groupUrl = `/groups/${groupSlug}` + (topic ? `/topics/${topic}` : '')
       }
       return url(`${groupUrl}/post/${getModelId(post)}`)
     },

--- a/api/services/Slack.js
+++ b/api/services/Slack.js
@@ -15,7 +15,7 @@ module.exports = {
     } else {
       return format('<%s|%s> posted <%s|%s> in <%s|%s>',
         Frontend.Route.profile(creator), creator.get('name'),
-        Frontend.Route.post(post, group), post.get('name'),
+        Frontend.Route.post(post, group), post.summary(),
         Frontend.Route.group(group), group.get('name'))
     }
   },

--- a/cron.js
+++ b/cron.js
@@ -71,7 +71,7 @@ const every10minutes = now => {
   sails.log.debug('Refreshing full-text search index, sending comment digests, updating member counts')
   return [
     FullTextSearch.refreshView(),
-    Comment.sendDigests().then(count => sails.log.debug(`Sent ${count} message digests`)),
+    Comment.sendDigests().then(count => sails.log.debug(`Sent ${count} comment/message digests`)),
     Group.updateAllMemberCounts()
   ]
 }

--- a/lib/group/digest2/savedSearches.js
+++ b/lib/group/digest2/savedSearches.js
@@ -12,7 +12,7 @@ const presentPost = async (p, context, slug) => {
   const { linkPreview } = post.relations
   return pickBy(x => x, {
     id: post.id,
-    title: post.get('name'),
+    title: post.summary(),
     details: RichText.qualifyLinks(post.details(), slug),
     user: presentAuthor(post),
     url: Frontend.Route.mapPost(post, context, slug),

--- a/test/unit/models/Comment.test.js
+++ b/test/unit/models/Comment.test.js
@@ -41,7 +41,7 @@ describe('Comment', () => {
   })
 
   describe('sendDigests', () => {
-    var u1, u2, post, comments, log, now
+    let u1, u2, post, comments, log, now, group
 
     beforeEach(async () => {
       now = new Date()
@@ -50,11 +50,13 @@ describe('Comment', () => {
 
       u1 = factories.user({avatar_url: 'foo.png', settings: {dm_notifications: 'both'}})
       u2 = factories.user({avatar_url: 'bar.png', settings: {dm_notifications: 'both'}})
-      post = factories.post({type: Post.Type.THREAD, updated_at: now})
+      group = factories.group({ name: 'group', slug: 'slug' })
+      post = factories.post({ type: Post.Type.THREAD, updated_at: now })
 
-      await Promise.join(u1.save(), u2.save())
+      await Promise.join(group.save(), u1.save(), u2.save())
       await post.save({ user_id: u1.id })
       await post.addFollowers([u1.id, u2.id])
+      await group.posts().attach(post)
       ;[u1.id, u2.id].forEach(userId =>
         times(2, i => comments.push(factories.comment({
           post_id: post.id,

--- a/test/unit/models/Comment.test.js
+++ b/test/unit/models/Comment.test.js
@@ -83,10 +83,12 @@ describe('Comment', () => {
           expect(send1.data.messages)
           .to.deep.equal([
             {
+              id: comments[2].id,
               text: comments[2].get('text'),
               name: u2.get('name'),
               avatar_url: u2.get('avatar_url')
             }, {
+              id: comments[3].id,
               text: comments[3].get('text'),
               name: u2.get('name'),
               avatar_url: u2.get('avatar_url')
@@ -96,10 +98,12 @@ describe('Comment', () => {
           expect(send2.data.messages)
           .to.deep.equal([
             {
+              id: comments[0].id,
               text: comments[0].get('text'),
               name: u1.get('name'),
               avatar_url: u1.get('avatar_url')
             }, {
+              id: comments[1].id,
               text: comments[1].get('text'),
               name: u1.get('name'),
               avatar_url: u1.get('avatar_url')
@@ -122,6 +126,7 @@ describe('Comment', () => {
           expect(log[0].email).to.equal(u1.get('email'))
           expect(log[0].data.messages)
           .to.deep.equal([{
+            id: comments[3].id,
             text: comments[3].get('text'),
             name: u2.get('name'),
             avatar_url: u2.get('avatar_url')
@@ -139,10 +144,12 @@ describe('Comment', () => {
           expect(log[0].email).to.equal(u2.get('email'))
           expect(log[0].data.messages)
           .to.deep.equal([{
+            id: comments[0].id,
             name: u1.get('name'),
             avatar_url: u1.get('avatar_url'),
             text: comments[0].get('text')
           }, {
+            id: comments[1].id,
             name: u1.get('name'),
             avatar_url: u1.get('avatar_url'),
             text: comments[1].get('text')

--- a/test/unit/models/FlaggedItem.test.js
+++ b/test/unit/models/FlaggedItem.test.js
@@ -184,7 +184,7 @@ describe('FlaggedItem', () => {
       })
       const link = await flaggedItem.getContentLink(group)
 
-      expect(link).to.equal(Frontend.Route.comment({ post: commentParent, group, comment }))
+      expect(link).to.equal(Frontend.Route.comment({ post: commentParent, groupSlug: group.get('slug'), comment }))
     })
 
     it('throws an error when object_type is bad', () => {

--- a/test/unit/models/Notification.test.js
+++ b/test/unit/models/Notification.test.js
@@ -346,6 +346,7 @@ describe('Notification', function () {
               text: () => 'I have an opinion',
               relations: {
                 post: model({
+                  summary: () => "hello world",
                   name: 'hello world',
                   relations: {
                     groups: [group]


### PR DESCRIPTION
Posts without titles
But also when clicking on notification jump to the chat post in the associated chat room

Also comment digest emails now link to the new comment, and in the context of the first group the post is in instead of /all

Fixes https://github.com/Hylozoic/hylo-node/issues/910 and more