### PR TITLE
939 timezone in emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [5.5.3] - 2023-08-09
+
+## Fixed
+- Show timezone for events in digest emails, for now always display in the time zone of the event creator
+
 ## [5.5.2] - 2023-06-12
 
 ## Fixed

--- a/api/graphql/makeModels.js
+++ b/api/graphql/makeModels.js
@@ -169,6 +169,7 @@ export default function makeModels (userId, isAdmin, apiClient) {
         'location',
         'project_management_link',
         'start_time',
+        'timezone',
         'type',
         'updated_at'
       ],
@@ -709,7 +710,7 @@ export default function makeModels (userId, isAdmin, apiClient) {
         'postcode'
       ]
     },
-    
+
     MessageThread: {
       model: Post,
       attributes: ['created_at', 'updated_at'],

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1601,6 +1601,8 @@ type Post {
   projectManagementLink: String
   # When this post "starts". Used for events, resources, projects, requests and offers right now
   startTime: Date
+  # The timezone of the post
+  timezone: String
   # The title text for the post
   title: String
   # Number of topics added to the post
@@ -2602,6 +2604,8 @@ input PostInput {
   projectManagementLink: String
   # When this post "starts". Used for events, resources, projects, requests and offers right now
   startTime: Date
+  # The timezone of the post
+  timezone: String
   # The title text for the post
   title: String
   # Topics to add to the post

--- a/api/models/Post.js
+++ b/api/models/Post.js
@@ -246,7 +246,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
     return Object.assign({},
       refineOne(
         this,
-        ['created_at', 'description', 'id', 'name', 'num_people_reacts', 'type', 'updated_at', 'num_votes'],
+        ['created_at', 'description', 'id', 'name', 'num_people_reacts', 'timezone', 'type', 'updated_at', 'num_votes'],
         { description: 'details', name: 'title', num_people_reacts: 'peopleReactedTotal', num_votes: 'votesTotal' }
       ),
       {
@@ -694,6 +694,7 @@ module.exports = bookshelf.Model.extend(Object.assign({
             isPublic: post.get('is_public'),
             location: post.get('location'),
             startTime: post.get('start_time'),
+            timezone: post.get('timezone'),
             title: post.summary(),
             type: post.get('type'),
             url: Frontend.Route.post(post),

--- a/api/models/post/setupPostAttrs.js
+++ b/api/models/post/setupPostAttrs.js
@@ -3,27 +3,26 @@ import { getOr } from 'lodash/fp'
 
 export default function setupPostAttrs (userId, params) {
   const attrs = merge({
-    user_id: userId,
+    accept_contributions: params.acceptContributions,
+    announcement: params.announcement,
+    donations_link: params.donationsLink,
+    end_time: params.endTime ? new Date(Number(params.endTime)) : null,
+    is_public: params.isPublic,
     link_preview_id: params.link_preview_id || getOr(null, 'id', params.linkPreview),
     parent_post_id: params.parent_post_id,
-    updated_at: new Date(),
-    announcement: params.announcement,
-    accept_contributions: params.acceptContributions,
-    donations_link: params.donationsLink,
     project_management_link: params.projectManagementLink,
     start_time: params.startTime ? new Date(Number(params.startTime)) : null,
-    end_time: params.endTime ? new Date(Number(params.endTime)) : null,
-    is_public: params.isPublic
+    updated_at: new Date(),
+    user_id: userId
   }, pick(params,
-    'name',
+    'created_from',
     'description',
-    'type',
-    'starts_at',
-    'ends_at',
     'link_preview_featured',
     'location_id',
     'location',
-    'created_from'
+    'name',
+    'timezone',
+    'type'
   ))
 
   return Promise.resolve(attrs)

--- a/lib/group/digest2/formatData.js
+++ b/lib/group/digest2/formatData.js
@@ -2,7 +2,6 @@
 import {
   curry, every, filter, find, isEmpty, map, pickBy, sortBy
 } from 'lodash/fp'
-import moment from 'moment-timezone'
 import { TextHelpers } from 'hylo-shared'
 
 const isChat = post => post.get('type') === 'chat'
@@ -16,11 +15,6 @@ const isDiscussion = post => post.get('type') === 'discussion'
 export const presentAuthor = obj =>
   obj.relations.user.pick('id', 'name', 'avatar_url')
 
-const humanDate = (date) => {
-  if (!date) return null
-  return moment(date).format('MMMM D, YYYY @ h:mma')
-}
-
 const presentPost = curry((slug, post) => {
   const { tags, linkPreview } = post.relations
 
@@ -31,7 +25,7 @@ const presentPost = curry((slug, post) => {
     user: presentAuthor(post),
     url: Frontend.Route.post(post, slug),
     location: isEvent(post) && post.get('location'),
-    when: isEvent(post) && humanDate(post.get('starts_at') || post.get('start_time')),
+    when: isEvent(post) && TextHelpers.formatDatePair(post.get('start_time'), post.get('end_time'), false, post.get('timezone')),
     comments: [],
     link_preview: linkPreview && linkPreview.id &&
       linkPreview.pick('title', 'description', 'url', 'image_url'),

--- a/lib/group/digest2/savedSearches.js
+++ b/lib/group/digest2/savedSearches.js
@@ -1,10 +1,9 @@
 import { merge, pick, pickBy } from 'lodash/fp'
+import { TextHelpers } from 'hylo-shared'
 import moment from 'moment-timezone'
 import { pluralize } from '../../util/normalize'
 import { presentAuthor } from '../digest2/formatData'
 import { sendToUser } from '../digest2'
-
-const humanDate = date => moment(date).format('MMMM D, YYYY')
 
 const presentPost = async (p, context, slug) => {
   const post = await Post.where({id: p.id}).fetch()
@@ -17,8 +16,8 @@ const presentPost = async (p, context, slug) => {
     user: presentAuthor(post),
     url: Frontend.Route.mapPost(post, context, slug),
     location: post.get('location'),
-    when: post.get('start_time') || post.get('end_time')
-      ? `${humanDate(post.get('start_time'))} ${humanDate(post.get('end_time')) ? `- ${humanDate(post.get('end_time'))}` : ''}`
+    when: post.get('start_time')
+      ? TextHelpers.formatDatePair(post.get('start_time'), post.get('end_time'), false, post.get('timezone'))
       : undefined,
     link_preview: linkPreview && linkPreview.id &&
       linkPreview.pick('title', 'description', 'url', 'image_url')

--- a/migrations/20230808216001_add-timezone-to-posts.js
+++ b/migrations/20230808216001_add-timezone-to-posts.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table('posts', t => {
+    t.string('timezone')
+  })
+}
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table('posts', t => {
+    t.dropColumn('timezone')
+  })
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Tibet Sprague <tibet@hylo.com>",
   "license": "GNU AFFERO GENERAL PUBLIC LICENSE v3",
   "private": true,
-  "version": "5.5.2",
+  "version": "5.5.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/Hylozoic/hylo-node.git"
@@ -104,7 +104,7 @@
     "hast-util-to-string": "^1.0.1",
     "hastscript": "^3.1.0",
     "he": "^1.2.0",
-    "hylo-shared": "5.2.3",
+    "hylo-shared": "5.2.5",
     "image-size": "^0.3.5",
     "insane": "^2.6.2",
     "jade": "^1.11.0",

--- a/test/unit/models/Media.test.js
+++ b/test/unit/models/Media.test.js
@@ -47,7 +47,7 @@ describe('Media', () => {
 
     it('returns the correct urls', async () => {
       const mediaUrls = await Media.findMediaUrlsForUser(user.id)
-      const expectedUrls = ['https://vimeo.com/70509133', 'http://i.vimeocdn.com/video/555280788-3f8ee9b5a9a54434acff9809c8ab998c22d26487171a868747a1ac4220a15110-d_640']
+      const expectedUrls = ['https://vimeo.com/70509133', 'https://i.vimeocdn.com/video/555280788-3f8ee9b5a9a54434acff9809c8ab998c22d26487171a868747a1ac4220a15110-d_640']
       expect(mediaUrls).to.deep.equal(expectedUrls)
     })
   })

--- a/test/unit/services/digest2.test.js
+++ b/test/unit/services/digest2.test.js
@@ -207,7 +207,7 @@ describe('group digest v2', () => {
             id: 76,
             title: 'An event',
             location: 'Home',
-            when: 'December 17, 1995 @ 6:30pm',
+            when: 'Sun, Dec 17, 1995 at 6:30PM PST',
             user: u2.attributes,
             url: Frontend.Route.post({id: 76}, group),
             comments: []

--- a/test/unit/services/digest2.test.js
+++ b/test/unit/services/digest2.test.js
@@ -35,7 +35,7 @@ const u4 = model({
   avatar_url: 'http://cnn.com/man.png'
 })
 
-const group = model({slug: 'foo'})
+const group = model({ slug: 'foo' })
 
 const linkPreview = model({
   id: '1',
@@ -48,6 +48,8 @@ const linkPreview = model({
 describe('group digest v2', () => {
   describe('formatData', () => {
     it('organizes new posts and comments', () => {
+      const eventStart = moment.tz(new Date(), moment.tz.guess())
+
       const data = {
         comments: [
           model({
@@ -119,7 +121,7 @@ describe('group digest v2', () => {
             details: () => {},
             type: 'event',
             location: 'Home',
-            start_time: new Date('December 17, 1995 18:30:00'),
+            start_time: eventStart,
             relations: {
               user: u2
             }
@@ -207,7 +209,7 @@ describe('group digest v2', () => {
             id: 76,
             title: 'An event',
             location: 'Home',
-            when: 'Sun, Dec 17, 1995 at 6:30PM PST',
+            when: eventStart.format('ddd, MMM D [at] h:mmA z'),
             user: u2.attributes,
             url: Frontend.Route.post({id: 76}, group),
             comments: []

--- a/yarn.lock
+++ b/yarn.lock
@@ -7084,10 +7084,10 @@ https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
-hylo-shared@5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-5.2.3.tgz#3c814dfece6bedca90800f6f0b30b03cc818f0b1"
-  integrity sha512-OzcCMMSZ/+6msIHaJc1fWQ4l3RFkKgjwTtaoARV07WOdEhqBaErTKPhRe71Sg2LGWeLPgECxQ2S5RmRITEtHFg==
+hylo-shared@5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/hylo-shared/-/hylo-shared-5.2.5.tgz#7db07a00072047adc1de3567cc33d67fef9113a3"
+  integrity sha512-FCh56lMedDStxNzR7ijn41Rv742qapcnMUM6A4TJ6Tsh+GUvLHIS928H2Tt1ST3C3lwP6egaiO1edCYsjX8Hmg==
   dependencies:
     coordinate-parser "^1.0.7"
     html-to-text "^8.1.0"


### PR DESCRIPTION
Show correct timezone for events in emails

For now this always shows the timezone set by/when the person created the event as the event's timezone, and displays that in the email.

Fixes https://github.com/Hylozoic/hylo-node/issues/939