### PR TITLE
Odds and ends

### DIFF
--- a/api/models/Group.js
+++ b/api/models/Group.js
@@ -619,8 +619,8 @@ module.exports = bookshelf.Model.extend(merge({
       }
     )
 
-    // XXX: for now allow all groups to appear in public by default
-    attrs.allow_in_public = true
+    // XXX: for now groups by default cannot post to public on production
+    attrs.allow_in_public = process.env.NODE_ENV === 'development'
 
     // eslint-disable-next-line camelcase
     const access_code = attrs.access_code || await Group.getNewAccessCode()

--- a/api/models/Notification.js
+++ b/api/models/Notification.js
@@ -388,7 +388,7 @@ module.exports = bookshelf.Model.extend({
             unfollow_url: Frontend.Route.tokenLogin(reader, token,
               Frontend.Route.unfollow(post, group) + '?ctt=announcement_email&cti=' + reader.id),
             tracking_pixel_url: Analytics.pixelUrl('Announcement', { userId: reader.id }),
-            post_date: TextHelpers.formatDatePair(post.get('start_time'), post.get('end_time'), false, post.get('timezone'))
+            post_date: post.get('start_time') ? TextHelpers.formatDatePair(post.get('start_time'), post.get('end_time'), false, post.get('timezone')) : null
           }
         })))
   },

--- a/api/models/ZapierTrigger.js
+++ b/api/models/ZapierTrigger.js
@@ -1,4 +1,4 @@
-import { castArray, isEmpty, isEqual, difference } from 'lodash'
+import { castArray } from 'lodash'
 
 module.exports = bookshelf.Model.extend(Object.assign({
   tableName: 'zapier_triggers',

--- a/api/models/comment/notifications.js
+++ b/api/models/comment/notifications.js
@@ -42,21 +42,23 @@ export const sendDigests = async () => {
 
   lastDigestAt = lastDigestAt ? new Date(Number(lastDigestAt)) : fallbackTime()
 
-  const posts = await Post.where('updated_at', '>', lastDigestAt).andWhere('active', true)
-    .fetchAll({
-      withRelated: [
-        {
-          comments: q => {
-            q.where('created_at', '>', lastDigestAt)
-            q.orderBy('created_at', 'asc')
-          }
-        },
-        'user',
-        'groups',
-        'comments.user',
-        'comments.media'
-      ]
-    })
+  const posts = await Post.query(q => {
+    q.where('updated_at', '>', lastDigestAt)
+    q.where('active', true)
+  }).fetchAll({
+    withRelated: [
+      {
+        comments: q => {
+          q.where('created_at', '>', lastDigestAt)
+          q.orderBy('created_at', 'asc')
+        }
+      },
+      'user',
+      'groups',
+      'comments.user',
+      'comments.media'
+    ]
+  })
 
   const numSends = await Promise.all(posts.map(async post => {
     const { comments } = post.relations

--- a/api/models/event/mixin.js
+++ b/api/models/event/mixin.js
@@ -7,8 +7,9 @@ export default {
   },
 
   eventInvitees: function () {
-    return this.belongsToMany(User).through(EventInvitation, 'event_id', 'user_id')
-    .withPivot('response')
+    return this.isEvent()
+      ? this.belongsToMany(User).through(EventInvitation, 'event_id', 'user_id').withPivot('response')
+      : false
   },
 
   eventInvitations: function () {

--- a/api/models/project/mixin.js
+++ b/api/models/project/mixin.js
@@ -7,7 +7,7 @@ export default {
   },
 
   members: function () {
-    return this.followers().query(q => q.whereRaw('project_role_id is not null'))
+    return this.isProject() ? this.followers().query(q => q.whereRaw('project_role_id is not null')) : false
   },
 
   addProjectMembers: async function (usersOrIds, opts) {
@@ -44,7 +44,7 @@ export default {
         post_id: this.id,
         name: ProjectRole.MEMBER_ROLE_NAME
       })
-      .save({}, opts)
+        .save({}, opts)
     }
   }
 }

--- a/api/services/Search/forPosts.js
+++ b/api/services/Search/forPosts.js
@@ -86,7 +86,8 @@ export default function forPosts (opts) {
     filterAndSortPosts(Object.assign({}, opts, {
       search: opts.term,
       sortBy: opts.sort,
-      showPinnedFirst: get(opts.groupIds, 'length') === 1
+      // Sort pinned posts first only when looking at a single group and not looking at chat room
+      showPinnedFirst: opts.type !== 'chat' && get(opts.groupIds, 'length') === 1
     }), qb)
 
     if (opts.omit) {

--- a/lib/group/digest2/index.js
+++ b/lib/group/digest2/index.js
@@ -68,13 +68,13 @@ export const sendDigest = (id, type, opts = {}) => {
       .then(ok => ok && getRecipients(id, type)
         .then(users => Promise.each(users, user => sendToUser(user, type, data, opts)))
         .then(users => users.length)))
-  }
+}
 
 export const sendAllDigests = (type, opts) =>
-  Group.where({active: true}).query().pluck('id')
-  .then(ids => Promise.map(ids, id =>
-    sendDigest(id, type, opts).then(count => count && [id, count]))
-  .then(compact))
+  Group.where({ active: true }).query().pluck('id')
+    .then(ids => Promise.map(ids, id =>
+      sendDigest(id, type, opts).then(count => count && [id, count]))
+      .then(compact))
 
 export const sendSampleData = address =>
   Email.sendSimpleEmail(address, templateId, sampleData)


### PR DESCRIPTION
- Turn off allow in public for new groups by default
- Fix null post time for notification emails for posts that dont have a start time
- Don't sort pinned posts first when getting posts for chat rooms
- Improve performance by loading eventInvites only for events and post members only for projects
- For post zapier triggers set URL to be post in URL in the first group instead of in the "all" groups context
- Cleanup