### PR TITLE
Node 1002 fix migrations and schema dump

### DIFF
--- a/migrations/20240218134105_proposals.js
+++ b/migrations/20240218134105_proposals.js
@@ -29,7 +29,7 @@ exports.up = async function (knex, Promise) {
     table.timestamp('created_at')
   })
 
-  await knex.raw('alter table proposal_options DROP CONSTRAINT proposal_options_post_id_foreign')
+  await knex.raw('alter table proposal_options DROP CONSTRAINT IF EXISTS proposal_options_post_id_foreign')
   await knex.raw('alter table proposal_votes alter constraint proposal_votes_post_id_foreign deferrable initially deferred')
   await knex.raw('alter table proposal_votes alter constraint proposal_votes_option_id_foreign deferrable initially deferred')
   await knex.raw('alter table proposal_votes alter constraint proposal_votes_user_id_foreign deferrable initially deferred')

--- a/migrations/20240721183827_restore-proposal-option-constraint.js
+++ b/migrations/20240721183827_restore-proposal-option-constraint.js
@@ -1,0 +1,8 @@
+
+exports.up = async function(knex) {
+  await knex.raw('alter table proposal_options DROP CONSTRAINT IF EXISTS proposal_options_post_id_foreign')
+  await knex.raw('alter table proposal_options ADD CONSTRAINT proposal_options_post_id_foreign FOREIGN KEY (post_id) REFERENCES posts(id) DEFERRABLE INITIALLY DEFERRED')
+}
+
+exports.down = async function(knex) {
+}

--- a/migrations/dump_schema.sh
+++ b/migrations/dump_schema.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-pg_dump -Osxn public hylo | sed -e 's/; Tablespace: $//'

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 14.2
--- Dumped by pg_dump version 14.2
+-- Dumped from database version 14.12 (Postgres.app)
+-- Dumped by pg_dump version 14.12 (Postgres.app)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -16,18 +16,23 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+--
+-- Name: postgis; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA public;
+
 
 --
--- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
+-- Name: EXTENSION postgis; Type: COMMENT; Schema: -; Owner: -
 --
 
-COMMENT ON SCHEMA public IS 'standard public schema';
+COMMENT ON EXTENSION postgis IS 'PostGIS geometry and geography spatial types and functions';
+
 
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
-
-CREATE EXTENSION postgis;
 
 --
 -- Name: activities; Type: TABLE; Schema: public; Owner: -
@@ -1964,6 +1969,7 @@ CREATE SEQUENCE public.project_roles_id_seq
 
 ALTER SEQUENCE public.project_roles_id_seq OWNED BY public.project_roles.id;
 
+
 --
 -- Name: proposal_options; Type: TABLE; Schema: public; Owner: -
 --
@@ -2028,6 +2034,7 @@ CREATE SEQUENCE public.proposal_votes_id_seq
 --
 
 ALTER SEQUENCE public.proposal_votes_id_seq OWNED BY public.proposal_votes.id;
+
 
 --
 -- Name: users_seq; Type: SEQUENCE; Schema: public; Owner: -
@@ -3076,6 +3083,7 @@ ALTER TABLE ONLY public.project_contributions ALTER COLUMN id SET DEFAULT nextva
 
 ALTER TABLE ONLY public.project_roles ALTER COLUMN id SET DEFAULT nextval('public.project_roles_id_seq'::regclass);
 
+
 --
 -- Name: proposal_options id; Type: DEFAULT; Schema: public; Owner: -
 --
@@ -3088,6 +3096,7 @@ ALTER TABLE ONLY public.proposal_options ALTER COLUMN id SET DEFAULT nextval('pu
 --
 
 ALTER TABLE ONLY public.proposal_votes ALTER COLUMN id SET DEFAULT nextval('public.proposal_votes_id_seq'::regclass);
+
 
 --
 -- Name: push_notifications id; Type: DEFAULT; Schema: public; Owner: -
@@ -3800,6 +3809,7 @@ ALTER TABLE ONLY public.project_contributions
 ALTER TABLE ONLY public.project_roles
     ADD CONSTRAINT project_roles_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: proposal_options proposal_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
@@ -3807,12 +3817,14 @@ ALTER TABLE ONLY public.project_roles
 ALTER TABLE ONLY public.proposal_options
     ADD CONSTRAINT proposal_options_pkey PRIMARY KEY (id);
 
+
 --
 -- Name: proposal_votes proposal_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.proposal_votes
     ADD CONSTRAINT proposal_votes_pkey PRIMARY KEY (id);
+
 
 --
 -- Name: questions questions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
@@ -5463,6 +5475,7 @@ ALTER TABLE ONLY public.project_contributions
 ALTER TABLE ONLY public.project_roles
     ADD CONSTRAINT project_roles_post_id_foreign FOREIGN KEY (post_id) REFERENCES public.posts(id) DEFERRABLE INITIALLY DEFERRED;
 
+
 --
 -- Name: proposal_options proposal_options_post_id_foreign; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
@@ -5493,7 +5506,6 @@ ALTER TABLE ONLY public.proposal_votes
 
 ALTER TABLE ONLY public.proposal_votes
     ADD CONSTRAINT proposal_votes_user_id_foreign FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED;
-
 
 
 --

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "migrate-make": "node ./node_modules/.bin/knex migrate:make",
     "debug": "node-debug app.js",
     "dev": "nf -j Procfile.dev -p 3001 start -t 1000",
-    "dump": "pg_dump -Osxn public hylo | sed -e 's/; Tablespace: $//' > migrations/schema.sql",
+    "dump": "pg_dump -Osx hylo | sed -e 's/; Tablespace: $//' -e 's/CREATE SCHEMA public;//' -e 's/ AS \"?column?\"//' -e \"s/'search_path', ''/'search_path', 'public'/\"  > migrations/schema.sql",
     "test": "[ \"$NODE_ENV\" != production ] && mocha -r test/setup/core -r @babel/register --exit",
     "cover": "./node_modules/.bin/nyc --cache -a -r lcov ./node_modules/.bin/mocha -r test/setup/core --require @babel/register -R dot --exit",
     "knex": "knex",


### PR DESCRIPTION
Fixes #1002 

Two commits:
- fix the migration so that hopefully it won't break any dev machines current or future
- revise yarn script so it can dump a schema that runs under test and dev

I ran hylo-node tests and they worked after running `yarn dump`
I dropped my dev db and ran the READ.ME commands:
- createdb...
- cat schema...
- yarn knex seed:run
and I was able to run, create an account, creat a group, and create a proposal. Yippee!