### PR TITLE
Node 1001 Correct transacting arguments, tests passing

### DIFF
--- a/api/graphql/mutations/post.js
+++ b/api/graphql/mutations/post.js
@@ -104,7 +104,7 @@ export async function updateProposalOptions ({ userId, postId, options }) {
   return Post.find(postId)
     .then(post => {
       if (post.get('proposal_status') === Post.Proposal_Status.COMPLETED && post.get('proposal_status') !== Post.Proposal_Status.CASUAL) throw new GraphQLYogaError("Proposal options cannot be changed once a proposal is complete'")
-      return post.updateProposalOptions({ options, userId, opts: { transacting: null, require: false } })
+      return post.updateProposalOptions({ options, userId })
     })
     .catch((err) => { throw new GraphQLYogaError(`setting of options failed: ${err}`) })
     .then(() => ({ success: true }))


### PR DESCRIPTION
Fixes #1001 

Existing pattern for Bookshelf arguments was inadvertently used when knex object is referenced.

Note:

The `opts.transacting ||= { transacting: false }` lines are a hack to tell knex when there are not transactions. This appears to only be the case in tests. This line is therefore necessary for tests that do not wrap database accesses in transactions. A proper fix would be to wrap tests in transactions, but that's more work than may be necessary.

Main disadvantage is reliance on `knex#transacting` not changing and breaking this. If that happens, it should only affect tests and not production.